### PR TITLE
[Feat] 회원가입 시 이메일 인증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// 이메일 발송 기능
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	//스웨거
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/src/main/java/com/demoday/ddangddangddang/controller/auth/AuthController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/auth/AuthController.java
@@ -1,4 +1,4 @@
-package com.demoday.ddangddangddang.controller;
+package com.demoday.ddangddangddang.controller.auth;
 
 import com.demoday.ddangddangddang.dto.auth.AccessTokenResponseDto;
 import com.demoday.ddangddangddang.dto.auth.LoginRequestDto;
@@ -6,7 +6,8 @@ import com.demoday.ddangddangddang.dto.auth.SignupRequestDto;
 import com.demoday.ddangddangddang.dto.auth.TokenRefreshRequestDto;
 import com.demoday.ddangddangddang.dto.auth.LoginResponseDto; // [수정] LoginResponseDto 경로가 dto/response에 있습니다.
 import com.demoday.ddangddangddang.global.apiresponse.ApiResponse;
-import com.demoday.ddangddangddang.service.AuthService;
+import com.demoday.ddangddangddang.service.auth.AuthService;
+import com.demoday.ddangddangddang.service.auth.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -22,6 +23,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @Tag(name = "Auth API", description = "사용자 인증 (회원가입, 로그인, 토큰 재발급) API - by 최우혁")
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -29,8 +32,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final EmailService emailService;
 
-    @Operation(summary = "회원가입", description = "이메일, 닉네임, 비밀번호로 회원가입을 진행합니다.")
+    @Operation(summary = "회원가입", description = "이메일, 닉네임, 비밀번호, 이메일 인증코드로 회원가입을 진행합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공",
                     content = @Content(mediaType = "application/json",
@@ -38,10 +42,15 @@ public class AuthController {
                             examples = @ExampleObject(value = "{\"isSuccess\":true,\"code\":\"COMMON2000\",\"message\":\"회원가입에 성공하였습니다.\",\"result\":null,\"error\":null}")
                     )
             ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 유효성 검증 실패 (예: 이메일 형식 오류, 닉네임 길이)",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 유효성 검증 실패 (예: 이메일 형식 오류, 닉네임 길이, 인증번호 누락)",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ApiResponse.class),
-                            examples = @ExampleObject(value = "{\"isSuccess\":false,\"code\":\"REQ_4002\",\"message\":\"파라미터 형식이 잘못되었습니다.\",\"result\":null,\"error\":\"[nickname] 닉네임은 2자 이상 10자 이하로 입력해주세요.\"}")
+                            examples = @ExampleObject(value = "{\"isSuccess\":false,\"code\":\"REQ_4002\",\"message\":\"파라미터 형식이 잘못되었습니다.\",\"result\":null,\"error\":\"[emailAuthCode] 이메일 인증번호를 입력해주세요.\"}")                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이메일 인증번호 불일치 (에러 코드 AUTH_4002)",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = "{\"isSuccess\":false,\"code\":\"AUTH_4002\",\"message\":\"이메일 인증번호가 유효하지 않습니다.\",\"result\":null,\"error\":\"인증번호가 일치하지 않습니다.\"}")
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이메일 또는 닉네임 중복 (에러 코드 AUTH_4001)",
@@ -58,6 +67,30 @@ public class AuthController {
         authService.signup(requestDto);
         ApiResponse<Void> response = ApiResponse.onSuccess("회원가입에 성공하였습니다.");
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "이메일 인증번호 발송", description = "회원가입을 위해 이메일로 인증번호를 발송합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증번호 발송 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = "{\"isSuccess\":true,\"code\":\"COMMON2000\",\"message\":\"인증번호가 성공적으로 발송되었습니다.\",\"result\":null,\"error\":null}")
+                    )
+            )
+    })
+    @PostMapping("/email/send-code")
+    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(
+            @RequestBody Map<String, String> emailMap
+    ) {
+        // @Email validation을 위해 DTO를 사용하는 것이 좋으나, 편의상 Map으로 받습니다.
+        String email = emailMap.get("email");
+        if (email == null || !email.contains("@")) {
+            throw new IllegalArgumentException("올바른 이메일 형식이 아닙니다.");
+        }
+
+        emailService.sendVerificationCode(email);
+        ApiResponse<Void> response = ApiResponse.onSuccess("인증번호가 성공적으로 발송되었습니다.");
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "로그인", description = "이메일, 비밀번호로 로그인을 진행하고 토큰을 발급합니다.")
@@ -113,4 +146,5 @@ public class AuthController {
         );
         return ResponseEntity.ok(response);
     }
+
 }

--- a/src/main/java/com/demoday/ddangddangddang/dto/auth/SignupRequestDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/auth/SignupRequestDto.java
@@ -21,4 +21,7 @@ public class SignupRequestDto {
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Size(min = 8, message = "비밀번호는 8자 이상으로 입력해주세요.")
     private String password;
+
+    @NotBlank(message = "이메일 인증번호를 입력해주세요.")
+    private String emailAuthCode;
 }

--- a/src/main/java/com/demoday/ddangddangddang/global/code/GeneralErrorCode.java
+++ b/src/main/java/com/demoday/ddangddangddang/global/code/GeneralErrorCode.java
@@ -13,6 +13,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
     MISSING_AUTH_INFO(HttpStatus.UNAUTHORIZED, "AUTH_4011", "인증 정보가 누락되었습니다."),
     INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "AUTH_4012", "올바르지 않은 아이디, 혹은 비밀번호입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4012", "유효하지 않은 토큰입니다."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "AUTH_4002", "이메일 인증번호가 유효하지 않습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_4031", "접근 권한이 없습니다."),
     TOKEN_EXPIRED(HttpStatus.valueOf(419), "AUTH_4191", "토큰이 만료되었습니다."),
 

--- a/src/main/java/com/demoday/ddangddangddang/service/ChatGptService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/ChatGptService.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class ChatGptService2 {
+public class ChatGptService {
 
     private final OpenAIClient openAIClient;
     private final ObjectMapper objectMapper;

--- a/src/main/java/com/demoday/ddangddangddang/service/auth/EmailService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/auth/EmailService.java
@@ -1,0 +1,95 @@
+package com.demoday.ddangddangddang.service.auth;
+
+import com.demoday.ddangddangddang.global.code.GeneralErrorCode;
+import com.demoday.ddangddangddang.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final StringRedisTemplate redisTemplate;
+    private static final String AUTH_CODE_PREFIX = "AuthCode:";
+    private static final long AUTH_CODE_EXPIRATION_MINUTES = 5; // 5분
+
+    /**
+     * 인증번호 이메일 발송
+     * (실제 발송은 주석 처리, 로그로 대체)
+     */
+    public void sendVerificationCode(String email) {
+        String authCode = createAuthCode();
+
+         // 1. (Mock) 이메일 발송
+
+         try {
+             SimpleMailMessage message = new SimpleMailMessage();
+             message.setTo(email);
+             message.setSubject("[땅땅땅] 회원가입 인증번호 안내");
+             message.setText("인증번호는 [" + authCode + "] 입니다.");
+             mailSender.send(message);
+         } catch (MailException e) {
+             log.error("이메일 발송 실패: {}", email, e);
+             throw new GeneralException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다.");
+         }
+
+        // (주의) 실제 발송 대신 로그 출력
+        log.info("[EmailService] 인증번호 발송 요청: {} / 인증번호: {}", email, authCode);
+
+        // 2. Redis에 인증번호 저장 (Key: "AuthCode:email@example.com", Value: "123456")
+        String redisKey = AUTH_CODE_PREFIX + email;
+        redisTemplate.opsForValue().set(
+                redisKey,
+                authCode,
+                AUTH_CODE_EXPIRATION_MINUTES,
+                TimeUnit.MINUTES
+        );
+    }
+
+    /**
+     * 인증번호 검증
+     */
+    public boolean verifyCode(String email, String code) {
+        String redisKey = AUTH_CODE_PREFIX + email;
+        String storedCode = redisTemplate.opsForValue().get(redisKey);
+
+        if (storedCode == null) {
+            // 인증번호가 만료되었거나 존재하지 않음
+            throw new GeneralException(GeneralErrorCode.INVALID_AUTH_CODE, "인증번호가 만료되었거나 존재하지 않습니다.");
+        }
+
+        if (!storedCode.equals(code)) {
+            // 인증번호 불일치
+            throw new GeneralException(GeneralErrorCode.INVALID_AUTH_CODE, "인증번호가 일치하지 않습니다.");
+        }
+
+        // 검증 성공
+        return true;
+    }
+
+    /**
+     * 인증 완료 후 Redis에서 코드 삭제
+     */
+    public void deleteCode(String email) {
+        String redisKey = AUTH_CODE_PREFIX + email;
+        redisTemplate.delete(redisKey);
+    }
+
+    /**
+     * 6자리 랜덤 인증번호 생성
+     */
+    private String createAuthCode() {
+        Random random = new Random();
+        int number = random.nextInt(899999) + 100000; // 100000 ~ 999999
+        return String.valueOf(number);
+    }
+}

--- a/src/main/java/com/demoday/ddangddangddang/service/cases/CaseService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/cases/CaseService.java
@@ -7,7 +7,7 @@ import com.demoday.ddangddangddang.dto.caseDto.*;
 import com.demoday.ddangddangddang.global.code.GeneralErrorCode;
 import com.demoday.ddangddangddang.global.exception.GeneralException;
 import com.demoday.ddangddangddang.repository.*;
-import com.demoday.ddangddangddang.service.ChatGptService2;
+import com.demoday.ddangddangddang.service.ChatGptService;
 import com.demoday.ddangddangddang.service.ranking.RankingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +23,7 @@ public class CaseService {
     private final CaseRepository caseRepository;
     private final ArgumentInitialRepository argumentInitialRepository;
     private final JudgmentRepository judgmentRepository;
-    private final ChatGptService2 chatGptService2;
+    private final ChatGptService chatGptService2;
     private final RankingService rankingService;
     private final CaseParticipationRepository caseParticipationRepository;
 

--- a/src/main/java/com/demoday/ddangddangddang/service/cases/DebateService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/cases/DebateService.java
@@ -8,7 +8,7 @@ import com.demoday.ddangddangddang.global.code.GeneralErrorCode;
 import com.demoday.ddangddangddang.global.event.UpdateJudgmentEvent;
 import com.demoday.ddangddangddang.global.exception.GeneralException;
 import com.demoday.ddangddangddang.repository.*;
-import com.demoday.ddangddangddang.service.ChatGptService2;
+import com.demoday.ddangddangddang.service.ChatGptService;
 import com.demoday.ddangddangddang.service.ranking.RankingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +35,7 @@ public class DebateService {
     private final LikeRepository likeRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final RankingService rankingService;
-    private final ChatGptService2 chatGptService2;
+    private final ChatGptService chatGptService2;
 
     /**
      * 2차 재판 시작 (시간제한 없음)

--- a/src/main/java/com/demoday/ddangddangddang/service/third/FinalJudgeService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/third/FinalJudgeService.java
@@ -14,7 +14,7 @@ import com.demoday.ddangddangddang.global.apiresponse.ApiResponse;
 import com.demoday.ddangddangddang.global.code.GeneralErrorCode;
 import com.demoday.ddangddangddang.global.exception.GeneralException;
 import com.demoday.ddangddangddang.repository.*;
-import com.demoday.ddangddangddang.service.ChatGptService2;
+import com.demoday.ddangddangddang.service.ChatGptService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
@@ -33,7 +33,7 @@ public class FinalJudgeService {
     private final RebuttalRepository rebuttalRepository;
     private final CaseRepository caseRepository; // aCase를 가져오기 위함
     private final ObjectMapper objectMapper;
-    private final ChatGptService2 chatGptService2;
+    private final ChatGptService chatGptService2;
 
     //판결문 저장
     public ApiResponse<Long> createJudge(Long caseId, FinalJudgmentRequestDto voteDto) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,6 +32,18 @@ spring:
       ssl:
         enabled: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_USERNAME}
+    password: ${GMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 jwt:
   secret:
     key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
[회원가입 UI 변경]에 따라 이메일 인증번호 발송 및 검증 로직을 구현합니다.

주요 변경 사항:
- `build.gradle`: 'spring-boot-starter-mail' 의존성 추가
- `application-dev.yml`: 이메일(SMTP) 서버 설정 추가
- `EmailService` (신규): 인증번호 생성, Redis 저장, 이메일 발송, 코드 검증 로직 구현
- `AuthController`: 이메일 인증번호 발송 API 엔드포인트 추가 (POST /api/v1/auth/email/send-code)
- `AuthService`: `signup` 시 `EmailService`를 호출하여 인증번호를 검증하도록 수정
- `SignupRequestDto`: 이메일 인증번호(`emailAuthCode`) 필드 추가
- `GeneralErrorCode`: 인증번호 관련 에러 코드 추가 (INVALID_AUTH_CODE)
- 'ChatGptService2' -> 'ChatGptService'로 이름 변경

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
