### PR TITLE
[Refactor] 이메일 인증 로직을 별도 API로 분리

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/dto/auth/EmailVerificationRequestDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/auth/EmailVerificationRequestDto.java
@@ -1,0 +1,17 @@
+package com.demoday.ddangddangddang.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailVerificationRequestDto {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email
+    private String email;
+
+    @NotBlank(message = "인증번호를 입력해주세요.")
+    private String code;
+}

--- a/src/main/java/com/demoday/ddangddangddang/dto/auth/SignupRequestDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/auth/SignupRequestDto.java
@@ -21,7 +21,4 @@ public class SignupRequestDto {
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Size(min = 8, message = "비밀번호는 8자 이상으로 입력해주세요.")
     private String password;
-
-    @NotBlank(message = "이메일 인증번호를 입력해주세요.")
-    private String emailAuthCode;
 }

--- a/src/main/java/com/demoday/ddangddangddang/global/code/GeneralErrorCode.java
+++ b/src/main/java/com/demoday/ddangddangddang/global/code/GeneralErrorCode.java
@@ -14,6 +14,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
     INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "AUTH_4012", "올바르지 않은 아이디, 혹은 비밀번호입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4012", "유효하지 않은 토큰입니다."),
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "AUTH_4002", "이메일 인증번호가 유효하지 않습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "AUTH_4003", "이메일 인증이 완료되지 않았습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_4031", "접근 권한이 없습니다."),
     TOKEN_EXPIRED(HttpStatus.valueOf(419), "AUTH_4191", "토큰이 만료되었습니다."),
 

--- a/src/main/java/com/demoday/ddangddangddang/service/auth/AuthService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/auth/AuthService.java
@@ -32,8 +32,8 @@ public class AuthService {
     @Transactional
     public void signup(SignupRequestDto requestDto) {
 
-        // 0. 이메일 인증번호 검증
-        emailService.verifyCode(requestDto.getEmail(), requestDto.getEmailAuthCode());
+        // 0. 이메일 '인증 완료' 상태 확인
+        emailService.checkEmailVerified(requestDto.getEmail());
 
         // 1. 이메일 중복 확인
         if (userRepository.existsByEmail(requestDto.getEmail())) {
@@ -65,8 +65,8 @@ public class AuthService {
                 .build();
         userRepository.save(user);
 
-        // 6. 회원가입 성공 시 Redis의 인증번호 삭제
-        emailService.deleteCode(requestDto.getEmail());
+        // 6. 회원가입 성공 시 Redis의 '인증 완료' 플래그 삭제
+        emailService.deleteVerifiedEmailFlag(requestDto.getEmail());
     }
 
     @Transactional


### PR DESCRIPTION
기존 `signup` API에서 직접 처리하던 이메일 인증번호 검증 로직을
`POST /api/v1/auth/email/verify-code` API로 분리합니다.

* `EmailService`가 인증 성공 시 Redis에 `VerifiedEmail:` 플래그를 저장하도록 변경합니다.
* `AuthService`는 `signup` 시 이 플래그를 검사하도록 수정합니다.
* `SignupRequestDto`에서 `emailAuthCode` 필드를 제거합니다.
* `EmailVerificationRequestDto`를 신규 추가합니다.

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
