### PR TITLE
[Fix] 이메일 발송 API가 DTO를 사용하도록 수정

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/auth/AuthController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/auth/AuthController.java
@@ -2,6 +2,7 @@ package com.demoday.ddangddangddang.controller.auth;
 
 import com.demoday.ddangddangddang.dto.auth.AccessTokenResponseDto;
 import com.demoday.ddangddangddang.dto.auth.EmailVerificationRequestDto;
+import com.demoday.ddangddangddang.dto.auth.EmailSendRequestDto;
 import com.demoday.ddangddangddang.dto.auth.LoginRequestDto;
 import com.demoday.ddangddangddang.dto.auth.SignupRequestDto;
 import com.demoday.ddangddangddang.dto.auth.TokenRefreshRequestDto;
@@ -81,15 +82,9 @@ public class AuthController {
     })
     @PostMapping("/email/send-code")
     public ResponseEntity<ApiResponse<Void>> sendVerificationCode(
-            @RequestBody Map<String, String> emailMap
+            @Valid @RequestBody EmailSendRequestDto requestDto
     ) {
-        // @Email validation을 위해 DTO를 사용하는 것이 좋으나, 편의상 Map으로 받습니다.
-        String email = emailMap.get("email");
-        if (email == null || !email.contains("@")) {
-            throw new IllegalArgumentException("올바른 이메일 형식이 아닙니다.");
-        }
-
-        emailService.sendVerificationCode(email);
+        emailService.sendVerificationCode(requestDto.getEmail());
         ApiResponse<Void> response = ApiResponse.onSuccess("인증번호가 성공적으로 발송되었습니다.");
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/demoday/ddangddangddang/dto/auth/EmailSendRequestDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/auth/EmailSendRequestDto.java
@@ -1,0 +1,14 @@
+package com.demoday.ddangddangddang.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailSendRequestDto {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}


### PR DESCRIPTION
[문제]
AuthController의 이메일 발송 API(`send-code`)가 `@RequestBody`를 `Map<String, String>`으로 받아, Swagger UI에서 Request Body 예시가 `additionalProp`으로 불명확하게 표시되는 문제가 있었음.

[수정 사항]
- `EmailSendRequestDto` (신규): 이메일 발송 요청(`email`) 전용 DTO 생성
- `AuthController` 수정: `sendVerificationCode` 메서드가 `Map` 대신 `@Valid EmailSendRequestDto`를 받도록 변경

[기대 효과]
- Swagger API 문서의 Request Body 명세가 명확해짐.
- `@Valid`를 통해 이메일 형식 검증을 컨트롤러단에서 수행.

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
