### PR TITLE
[Feat] VS 모드 매칭 대기방 기능 구현

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/cases/CaseController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/cases/CaseController.java
@@ -1,6 +1,7 @@
 package com.demoday.ddangddangddang.controller.cases;
 
 import com.demoday.ddangddangddang.dto.caseDto.*;
+import com.demoday.ddangddangddang.dto.caseDto.party.CasePendingResponseDto;
 import com.demoday.ddangddangddang.global.apiresponse.ApiResponse;
 import com.demoday.ddangddangddang.global.security.UserDetailsImpl;
 import com.demoday.ddangddangddang.service.cases.CaseService;
@@ -14,6 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Case (1차 재판) API", description = "사건 생성(1차 재판) 관련 API - by 최우혁")
 @SecurityRequirement(name = "JWT TOKEN")
 @RestController
@@ -25,7 +28,8 @@ public class CaseController {
 
     // --- [ 1차 재판 API (기존) ] ---
 
-    @Operation(summary = "1차 재판(초심) 생성 (솔로 모드)")
+    @Operation(summary = "1차 재판(초심) 생성 (솔로/VS 모드)", description = "mode: SOLO(솔로), PARTY(VS모드)")
+    @SecurityRequirement(name = "JWT TOKEN")
     @PostMapping
     public ResponseEntity<ApiResponse<CaseResponseDto>> createCase(
             @Valid @RequestBody CaseRequestDto requestDto,
@@ -36,7 +40,30 @@ public class CaseController {
                 .body(ApiResponse.onSuccess("사건이 성공적으로 생성되었습니다.", responseDto));
     }
 
+    // VS 모드 대기 목록 조회
+    @Operation(summary = "VS 모드 매칭 대기 목록 조회", description = "매칭 대기 중(PENDING)인 사건 목록을 조회합니다.")
+    @GetMapping("/pending")
+    public ResponseEntity<ApiResponse<List<CasePendingResponseDto>>> getPendingCases() {
+        List<CasePendingResponseDto> responseDto = caseService.getPendingCases();
+        return ResponseEntity.ok(ApiResponse.onSuccess("매칭 대기 중인 사건 목록 조회 성공", responseDto));
+    }
+
+    // VS 모드 1차 입장문 제출 (참여)
+    @Operation(summary = "VS 모드 1차 입장문 제출 (참여)", description = "PENDING 상태인 사건에 B측 입장문을 제출하여 참여합니다.")
+    @SecurityRequirement(name = "JWT TOKEN")
+    @PostMapping("/{caseId}/arguments")
+    public ResponseEntity<ApiResponse<Void>> createInitialArgument(
+            @PathVariable Long caseId,
+            @Valid @RequestBody ArgumentInitialRequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        caseService.createInitialArgument(caseId, requestDto, userDetails.getUser());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.onSuccess("B측 입장문이 성공적으로 등록되었습니다. 1차 재판이 시작됩니다."));
+    }
+
     @Operation(summary = "사건 상세 조회 (1차 입장문 포함)")
+    @SecurityRequirement(name = "JWT TOKEN")
     @GetMapping("/{caseId}")
     public ResponseEntity<ApiResponse<CaseDetailResponseDto>> getCaseDetail(
             @PathVariable Long caseId,
@@ -47,6 +74,7 @@ public class CaseController {
     }
 
     @Operation(summary = "1차 재판(초심) AI 판결 결과 조회")
+    @SecurityRequirement(name = "JWT TOKEN")
     @GetMapping("/{caseId}/judgment")
     public ResponseEntity<ApiResponse<JudgmentResponseDto>> getJudgment(
             @PathVariable Long caseId,
@@ -57,6 +85,7 @@ public class CaseController {
     }
 
     @Operation(summary = "1차 재판 상태 변경 (종료)", description = "1차 판결 확인 후, 사건을 완전히 종료(DONE)시킵니다.")
+    @SecurityRequirement(name = "JWT TOKEN")
     @PatchMapping("/{caseId}/status")
     public ResponseEntity<ApiResponse<Void>> updateCaseStatus(
             @PathVariable Long caseId,

--- a/src/main/java/com/demoday/ddangddangddang/domain/enums/Rank.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/enums/Rank.java
@@ -4,14 +4,22 @@ import lombok.Getter;
 
 @Getter
 public enum Rank {
-    PARTNER_LAWYER("파트너 변호사", 4000L),
-    SENIOR_LAWYER("시니어 변호사", 3000L),
-    MID_LEVEL_LAWYER("중견 변호사", 2200L),
-    JUNIOR_LAWYER("신입 변호사", 1600L),
-    LAW_SCHOOL_STUDENT("로스쿨생", 1100L),
-    LAW_STUDENT("법대생", 700L),
-    MASTER_BRAWLER("말싸움 고수", 400L),
-    MID_BRAWLER("말싸움 중수", 200L),
+    PARTNER_LAWYER("파트너 변호사", 6000L),
+    SENIOR_LAWYER("시니어 변호사", 5200L),
+    MID_LEVEL_LAWYER("중견 변호사", 4500L),
+    JUNIOR_LAWYER("신입 변호사", 3850L),
+
+    LAW_SCHOOL_GRADUATE("로스쿨 졸업반", 3250L),
+    LAW_SCHOOL_2L("로스쿨 2학년", 2700L),
+    LAW_SCHOOL_1L("로스쿨 1학년", 2200L),
+
+    LAW_STUDENT_SENIOR("법대생 졸업반", 1750L),
+    LAW_STUDENT_JUNIOR("법대생 3학년", 1350L),
+    LAW_STUDENT_SOPHOMORE("법대생 2학년", 1000L),
+    LAW_STUDENT_FRESHMAN("법대생 1학년", 700L),
+
+    MASTER_BRAWLER("말싸움 고수", 450L),
+    MID_BRAWLER("말싸움 중수", 250L),
     NOVICE_BRAWLER("말싸움 하수", 100L),
     NEWBIE_BRAWLER("말싸움 풋내기", 0L);
 

--- a/src/main/java/com/demoday/ddangddangddang/dto/caseDto/party/CasePendingResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/caseDto/party/CasePendingResponseDto.java
@@ -1,0 +1,28 @@
+package com.demoday.ddangddangddang.dto.caseDto.party;
+
+import com.demoday.ddangddangddang.domain.ArgumentInitial;
+import com.demoday.ddangddangddang.domain.Case;
+import com.demoday.ddangddangddang.domain.enums.DebateSide;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CasePendingResponseDto {
+    private Long caseId;
+    private String title;
+    private String argumentAMain;
+    private LocalDateTime createdAt; // 등록 시간
+
+    public CasePendingResponseDto(Case aCase, ArgumentInitial argumentA) {
+        this.caseId = aCase.getId();
+        this.title = aCase.getTitle();
+        // A측 입장문이 존재하고 타입이 A가 맞는지 확인
+        if (argumentA != null && argumentA.getType() == DebateSide.A) {
+            this.argumentAMain = argumentA.getMainArgument();
+        } else {
+            this.argumentAMain = "입장 확인 중..."; // 예외 처리
+        }
+        this.createdAt = aCase.getCreatedAt();
+    }
+}

--- a/src/main/java/com/demoday/ddangddangddang/global/config/SecurityConfig.java
+++ b/src/main/java/com/demoday/ddangddangddang/global/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll() // Swagger 허용
                 .requestMatchers("/", "/health-check").permitAll()
                 .requestMatchers("/*").permitAll() // HomeController의 "/" 경로 허용
+                .requestMatchers(HttpMethod.GET,"/api/v1/cases/pending").permitAll()
                 .requestMatchers(HttpMethod.GET,"/api/v1/cases/{caseId}","/api/v1/cases/{caseId}/defenses").permitAll()
                 .requestMatchers(HttpMethod.GET,"api/v1/defenses/{defenseId}/rebuttals").permitAll()
                 .requestMatchers(HttpMethod.GET,"/api/v1/cases/{caseId}/vote/result").permitAll()

--- a/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
@@ -1,9 +1,14 @@
 package com.demoday.ddangddangddang.repository;
 
 import com.demoday.ddangddangddang.domain.Case;
+import com.demoday.ddangddangddang.domain.enums.CaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CaseRepository extends JpaRepository<Case,Long> {
+    // PENDING 상태인 사건들을 생성일자 내림차순(최신순)으로 조회
+    List<Case> findAllByStatusOrderByCreatedAtDesc(CaseStatus status);
 }


### PR DESCRIPTION
'재판 매칭 대기' 게시판 화면 구현을 위한 백엔드 API를 추가합니다.
CaseStatus가 PENDING인 사건 목록을 조회하고, B측 사용자가 해당 사건에 1차 입장문을 제출하여 참여할 수 있는 기능을 구현했습니다. 사용자 등급(Rank) 체계를 기존 10단계에서 15단계로 세분화하여 개편합니다.

주요 변경 사항:
- CaseController:
  - `GET /api/v1/cases/pending`: 매칭 대기 목록 조회 API 추가
  - `POST /api/v1/cases/{caseId}/arguments`: B측 입장문 제출(참여) API 추가

- CaseService:
  - `getPendingCases()`: 매칭 대기 목록 조회 서비스 로직 구현 (N+1 문제 방지)
  - `createPartyCase()`: VS 모드 생성 시, A측 입장문도 함께 저장하도록 로직 변경
  - `createInitialArgument()`: B측 사용자가 참여 시 호출되는 로직 (기존 로직 활용)

- CaseRepository:
  - `findAllByStatusOrderByCreatedAtDesc`: PENDING 상태 사건 조회 쿼리 추가

- DTO:
  - `CasePendingResponseDto.java`: 대기 목록 응답용 DTO 신규 생성

- SecurityConfig:
  - `GET /api/v1/cases/pending` 엔드포인트 permitAll 추가

  - '말싸움' 등급 (4단계)
  - '법대생' 등급 (4단계)
  - '로스쿨' 등급 (3단계)
  - '변호사' 등급 (4단계)

  각 단계별 필요 경험치(minExp)를 재조정했습니다.

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
