### PR TITLE
[Feat] 판결 아카이빙 스케줄러 및 히스토리 조회 API 추가

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/cases/DebateController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/cases/DebateController.java
@@ -2,6 +2,7 @@ package com.demoday.ddangddangddang.controller.cases;
 
 import com.demoday.ddangddangddang.domain.Defense;
 import com.demoday.ddangddangddang.domain.Rebuttal;
+import com.demoday.ddangddangddang.dto.caseDto.JudgmentResponseDto;
 import com.demoday.ddangddangddang.dto.caseDto.second.*;
 import com.demoday.ddangddangddang.global.apiresponse.ApiResponse;
 import com.demoday.ddangddangddang.global.security.UserDetailsImpl;

--- a/src/main/java/com/demoday/ddangddangddang/controller/third/FinalJudgeController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/third/FinalJudgeController.java
@@ -1,16 +1,21 @@
 package com.demoday.ddangddangddang.controller.third;
 
+import com.demoday.ddangddangddang.dto.caseDto.JudgmentResponseDto;
 import com.demoday.ddangddangddang.dto.third.FinalJudgmentRequestDto;
 import com.demoday.ddangddangddang.dto.third.JudgementDetailResponseDto;
 import com.demoday.ddangddangddang.global.apiresponse.ApiResponse;
 import com.demoday.ddangddangddang.global.security.UserDetailsImpl;
+import com.demoday.ddangddangddang.service.cases.DebateService;
 import com.demoday.ddangddangddang.service.third.FinalJudgeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "FINALJUDGE API", description = "최종 판결 API -by 황신애")
 @RestController
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/final/judge")
 public class FinalJudgeController {
     private final FinalJudgeService finalJudgeService;
+    private final DebateService debateService;
 
     @SecurityRequirement(name = "JWT TOKEN")
     @Operation(summary = "판결문 생성", description = "사건에 대한 최종판결문을 생성합니다")
@@ -34,5 +40,11 @@ public class FinalJudgeController {
     @GetMapping("/{caseId}")
     public ApiResponse<JudgementDetailResponseDto> getFinalJudgment(@PathVariable Long caseId){
         return finalJudgeService.getFinalJudgemnet(caseId);
+    }
+
+    @Operation(summary = "최종 판결 히스토리 조회 (아카이브)", description = "최종심이 진행되며 아카이빙된 모든 '판결 스냅샷' 목록을 오래된 순으로 조회합니다.")
+    @GetMapping("/{caseId}/history") // [✅ 신규 API]
+    public ApiResponse<List<JudgmentResponseDto>> getFinalJudgmentHistory(@PathVariable Long caseId) {
+        return finalJudgeService.getJudgmentHistory(caseId);
     }
 }

--- a/src/main/java/com/demoday/ddangddangddang/global/event/JudgmentEventListener.java
+++ b/src/main/java/com/demoday/ddangddangddang/global/event/JudgmentEventListener.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class JudgmentEventListener {
-
+/*
     // private final CaseService caseService; // ⭐️ (주의) 순환 참조 방지
     private final DebateService debateService; // ⭐️ 호출할 서비스 변경
 
@@ -20,4 +20,6 @@ public class JudgmentEventListener {
         // caseService.updateFinalJudgment(event.getCaseId()); // ⭐️ 변경 전
         debateService.updateFinalJudgment(event.getCaseId()); // ⭐️ 변경 후
     }
+
+ */
 }

--- a/src/main/java/com/demoday/ddangddangddang/repository/JudgmentRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/JudgmentRepository.java
@@ -5,6 +5,7 @@ import com.demoday.ddangddangddang.domain.enums.JudgmentStage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +14,7 @@ public interface JudgmentRepository extends JpaRepository<Judgment, Long> {
     Optional<Judgment> findByaCase_IdAndStage(Long caseId, JudgmentStage stage);
 
     Optional<Judgment> findTopByaCase_IdAndStageOrderByCreatedAtDesc(Long caseId, JudgmentStage stage);
+
+    // 특정 사건의 FINAL 스테이지 판결을 '오래된 순'으로 모두 조회
+    List<Judgment> findAllByaCase_IdAndStageOrderByCreatedAtAsc(Long caseId, JudgmentStage stage);
 }

--- a/src/main/java/com/demoday/ddangddangddang/service/cases/JudgmentUpdateScheduler.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/cases/JudgmentUpdateScheduler.java
@@ -1,0 +1,49 @@
+package com.demoday.ddangddangddang.service.cases;
+
+import com.demoday.ddangddangddang.domain.Case;
+import com.demoday.ddangddangddang.domain.enums.CaseStatus;
+import com.demoday.ddangddangddang.repository.CaseRepository;
+import com.demoday.ddangddangddang.service.third.FinalJudgeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JudgmentUpdateScheduler {
+
+    private final CaseRepository caseRepository;
+    private final FinalJudgeService finalJudgeService;
+
+    /**
+     * 매일 자정에 최종심(THIRD)이 진행 중인 모든 사건의 판결 스냅샷을 생성(아카이빙)합니다.
+     */
+    @Scheduled(cron = "0 0 0 * * *") // 매일 0시 0분 0초에 실행
+    public void archiveDailyJudgments() {
+        log.info("[Scheduler] 일일 판결 스냅샷 생성을 시작합니다.");
+
+        // 최종심 상태인 모든 사건을 조회
+        List<Case> activeCases = caseRepository.findAllByStatusOrderByCreatedAtDesc(CaseStatus.THIRD);
+
+        if (activeCases.isEmpty()) {
+            log.info("[Scheduler] 최종심(THIRD)이 진행 중인 사건이 없습니다.");
+            return;
+        }
+
+        log.info("[Scheduler] 총 {}개의 최종심 사건에 대한 스냅샷 생성을 시도합니다.", activeCases.size());
+
+        for (Case aCase : activeCases) {
+            try {
+                finalJudgeService.createDailyJudgmentSnapshot(aCase.getId());
+            } catch (Exception e) {
+                log.error("[Scheduler] Case ID {} 판결 스냅샷 생성 중 오류 발생: {}", aCase.getId(), e.getMessage(), e);
+            }
+        }
+
+        log.info("[Scheduler] 일일 판결 스냅샷 생성을 완료했습니다.");
+    }
+}


### PR DESCRIPTION
2차 재판과 최종심의 판결 로직을 개편합니다. 주요 변경 사항은 다음과 같습니다.


실시간 AI 판결 이벤트 중지 (Refactor):

DebateService에서 변론, 반론, 투표 시 호출되던 UpdateJudgmentEvent를 주석 처리합니다.

2차 재판 중 불필요한 AI 호출 및 토큰 낭비를 방지합니다.


일일 판결 스냅샷 스케줄러 추가 (Feat):

JudgmentUpdateScheduler를 신규 생성하여 매일 자정(0 0 0 * * *)에 동작하도록 합니다.

스케줄러는 CaseStatus.THIRD(최종심) 상태의 모든 사건을 대상으로 FinalJudgeService의 createDailyJudgmentSnapshot 메서드를 호출합니다.


판결 아카이빙 로직 구현 (Perf / Feat):

createDailyJudgmentSnapshot 메서드 (in FinalJudgeService)는 A/B 진영별 '좋아요 Top 5' 변론/반론 목록을 조회합니다.

이 Top 5 항목 ID를 JudgementBasisDto로 변환하고 JSON 문자열로 만듭니다.

이 JSON을 DB에 저장된 가장 최근 판결의 basedOn 필드와 비교합니다.

변경 사항이 없을 경우(JSON 동일), AI 호출 및 스냅샷 생성을 건너뛰어 리소스를 절약합니다.

변경 사항이 있을 경우, AI 판결을 새로 받아 Judgment 엔티티를 save하여 판결을 아카이빙합니다.


판결 히스토리 조회 API 추가 (Feat):

JudgmentRepository에 findAllByaCase_IdAndStageOrderByCreatedAtAsc 메서드를 추가합니다.

FinalJudgeService에 getJudgmentHistory 메서드를 추가합니다.

FinalJudgeController에 GET /api/final/judge/{caseId}/history 엔드포인트를 추가하여, 아카이빙된 모든 판결 이력을 오래된 순으로 조회할 수 있게 합니다.

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#35]
