### PR TITLE
[Feat] 변론/반론 신고 기능 구현 및 API 추가

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/report/ReportController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/report/ReportController.java
@@ -1,0 +1,39 @@
+package com.demoday.ddangddangddang.controller.report;
+
+import com.demoday.ddangddangddang.dto.report.ReportRequestDto;
+import com.demoday.ddangddangddang.global.apiresponse.ApiResponse;
+import com.demoday.ddangddangddang.global.security.UserDetailsImpl;
+import com.demoday.ddangddangddang.service.report.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+@Tag(name = "Report API", description = "신고하기 API")
+@SecurityRequirement(name = "JWT TOKEN")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @Operation(summary = "변론/반론 신고하기", description = "부적절한 변론(DEFENSE) 또는 반론(REBUTTAL)을 신고합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createReport(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody ReportRequestDto requestDto
+    ) {
+        reportService.createReport(userDetails.getUser().getId(), requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.onSuccess("신고가 성공적으로 접수되었습니다."));
+    }
+}

--- a/src/main/java/com/demoday/ddangddangddang/domain/Report.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/Report.java
@@ -1,0 +1,49 @@
+package com.demoday.ddangddangddang.domain;
+
+import com.demoday.ddangddangddang.domain.enums.ContentType;
+import com.demoday.ddangddangddang.domain.enums.ReportReason;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "reports", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"reporter_id", "content_id", "content_type"}) // 중복 신고 방지
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter; // 신고자
+
+    @Column(name = "content_id", nullable = false)
+    private Long contentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "content_type", nullable = false)
+    private ContentType contentType; // DEFENSE(변론) or REBUTTAL(반론)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason", nullable = false)
+    private ReportReason reason; // 신고 사유
+
+    @Column(name = "custom_reason", columnDefinition = "TEXT")
+    private String customReason; // 기타 사유일 경우 상세 내용
+
+    @Builder
+    public Report(User reporter, Long contentId, ContentType contentType, ReportReason reason, String customReason) {
+        this.reporter = reporter;
+        this.contentId = contentId;
+        this.contentType = contentType;
+        this.reason = reason;
+        this.customReason = customReason;
+    }
+}

--- a/src/main/java/com/demoday/ddangddangddang/domain/enums/ReportReason.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/enums/ReportReason.java
@@ -1,0 +1,17 @@
+package com.demoday.ddangddangddang.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportReason {
+    PROFANITY("욕설/비하 발언"),
+    SLANDER("인신공격/명예훼손"),
+    SPAM("도배/스팸"),
+    ADVERTISEMENT("상업적 광고"),
+    OBSCENE("음란성/부적절한 홍보"),
+    OTHER("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/demoday/ddangddangddang/dto/report/ReportRequestDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/report/ReportRequestDto.java
@@ -1,0 +1,28 @@
+package com.demoday.ddangddangddang.dto.report;
+
+import com.demoday.ddangddangddang.domain.enums.ContentType;
+import com.demoday.ddangddangddang.domain.enums.ReportReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReportRequestDto {
+
+    @NotNull(message = "신고할 콘텐츠 ID는 필수입니다.")
+    @Schema(description = "변론(Defense) 또는 반론(Rebuttal)의 ID", example = "1")
+    private Long contentId;
+
+    @NotNull(message = "콘텐츠 타입은 필수입니다.")
+    @Schema(description = "콘텐츠 타입 (DEFENSE, REBUTTAL)", example = "DEFENSE")
+    private ContentType contentType;
+
+    @NotNull(message = "신고 사유를 선택해주세요.")
+    @Schema(description = "신고 사유 (PROFANITY, SLANDER, SPAM, ADVERTISEMENT, OBSCENE, OTHER)", example = "PROFANITY")
+    private ReportReason reason;
+
+    @Schema(description = "기타 사유 상세 내용 (선택)", example = "지나친 욕설이 포함되어 있습니다.")
+    private String customReason;
+}

--- a/src/main/java/com/demoday/ddangddangddang/global/code/GeneralErrorCode.java
+++ b/src/main/java/com/demoday/ddangddangddang/global/code/GeneralErrorCode.java
@@ -38,6 +38,9 @@ public enum GeneralErrorCode implements BaseErrorCode {
     //사건 에러
     CASE_NOT_FOUND(HttpStatus.NOT_FOUND,"CASE_4041","사건을 찾을 수 없습니다."),
 
+    // 기존 Enum에 아래 코드 추가
+    REPORT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "REPORT_4001", "이미 신고한 콘텐츠입니다."),
+
     //판결 에러
     JUDGE_NOT_FOUND(HttpStatus.NOT_FOUND,"JUDGE_4041","판결을 찾을 수 없습니다.");
 

--- a/src/main/java/com/demoday/ddangddangddang/repository/ReportRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/ReportRepository.java
@@ -1,0 +1,13 @@
+package com.demoday.ddangddangddang.repository;
+
+import com.demoday.ddangddangddang.domain.Report;
+import com.demoday.ddangddangddang.domain.User;
+import com.demoday.ddangddangddang.domain.enums.ContentType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    // 이미 신고했는지 확인
+    boolean existsByReporterAndContentIdAndContentType(User reporter, Long contentId, ContentType contentType);
+}

--- a/src/main/java/com/demoday/ddangddangddang/service/report/ReportService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/report/ReportService.java
@@ -1,0 +1,64 @@
+package com.demoday.ddangddangddang.service.report;
+
+import com.demoday.ddangddangddang.domain.Report;
+import com.demoday.ddangddangddang.domain.User;
+import com.demoday.ddangddangddang.domain.enums.ContentType;
+import com.demoday.ddangddangddang.dto.report.ReportRequestDto;
+import com.demoday.ddangddangddang.global.code.GeneralErrorCode;
+import com.demoday.ddangddangddang.global.exception.GeneralException;
+import com.demoday.ddangddangddang.repository.DefenseRepository;
+import com.demoday.ddangddangddang.repository.RebuttalRepository;
+import com.demoday.ddangddangddang.repository.ReportRepository;
+import com.demoday.ddangddangddang.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final DefenseRepository defenseRepository;
+    private final RebuttalRepository rebuttalRepository;
+
+    public void createReport(Long userId, ReportRequestDto requestDto) {
+        User reporter = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+
+        // 1. 콘텐츠 존재 여부 확인
+        validateContentExists(requestDto.getContentId(), requestDto.getContentType());
+
+        // 2. 중복 신고 확인
+        if (reportRepository.existsByReporterAndContentIdAndContentType(reporter, requestDto.getContentId(), requestDto.getContentType())) {
+            throw new GeneralException(GeneralErrorCode.REPORT_ALREADY_EXISTS);
+        }
+
+        // 3. 신고 저장
+        Report report = Report.builder()
+                .reporter(reporter)
+                .contentId(requestDto.getContentId())
+                .contentType(requestDto.getContentType())
+                .reason(requestDto.getReason())
+                .customReason(requestDto.getCustomReason())
+                .build();
+
+        reportRepository.save(report);
+    }
+
+    private void validateContentExists(Long contentId, ContentType contentType) {
+        if (contentType == ContentType.DEFENSE) {
+            if (!defenseRepository.existsById(contentId)) {
+                throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "존재하지 않는 변론입니다.");
+            }
+        } else if (contentType == ContentType.REBUTTAL) {
+            if (!rebuttalRepository.existsById(contentId)) {
+                throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "존재하지 않는 반론입니다.");
+            }
+        } else {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "잘못된 콘텐츠 타입입니다.");
+        }
+    }
+}


### PR DESCRIPTION
부적절한 콘텐츠(변론/반론)에 대한 사용자 신고 기능을 추가하고, 중복 신고 방지 및 콘텐츠 유효성 검사를 포함하는 비즈니스 로직을 구현했습니다.

상세 변경 내용
신고 도메인 및 DTO 정의

ReportReason enum을 정의하여 신고 사유(욕설, 스팸, 광고 등)를 분류했습니다.

Report 엔티티를 생성하고, 신고자(reporter), 콘텐츠 ID, ContentType, 사유 등을 저장합니다.

ReportRequestDto를 추가하여 신고 요청 데이터의 유효성을 검증합니다.

비즈니스 로직 및 API

ReportRepository에 신고 이력 조회 메서드를 추가하여 사용자당 중복 신고를 방지합니다.

ReportService를 구현하여 신고 접수 로직을 담당하며, 신고 대상 콘텐츠(Defense/Rebuttal)의 존재 여부를 검증합니다.

ReportController에 POST /api/v1/reports 엔드포인트를 추가하여 인증된 사용자만 신고를 요청할 수 있도록 설정했습니다.

시스템 업데이트

GeneralErrorCode에 REPORT_ALREADY_EXISTS 코드를 추가했습니다.

SecurityConfig에 /api/v1/reports 경로에 대한 POST 요청 인증 규칙을 적용했습니다.

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#59  ]
