### PR TITLE
[Feat] 신고 누적 시 콘텐츠 숨김 처리 (BLIND 기능) 구현 및 반영

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/domain/Defense.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/Defense.java
@@ -44,6 +44,11 @@ public class Defense extends BaseEntity {
     @Column(name = "is_adopted", nullable = false)
     private Boolean isAdopted = false;
 
+    // 신고 5회 당하면 블라인드 되는거
+    @Builder.Default
+    @Column(name = "is_blind", nullable = false)
+    private Boolean isBlind = false;
+
     @Builder.Default
     @Column(name = "case_result")
     private CaseResult caseResult = CaseResult.PENDING;
@@ -60,13 +65,14 @@ public class Defense extends BaseEntity {
 
     public void markAsAdoptedFalse() { this.isAdopted = false; }
 
+    public void markAsBlind() { this.isBlind = true; }
+
     public void incrementLikesCount() { this.likesCount++; }
 
     public void decrementLikesCount() {
         if (this.likesCount > 0) this.likesCount--;
     }
 
-    // 결과 업데이트 메서드
     public void updateResult(CaseResult result) {
         this.caseResult = result;
     }

--- a/src/main/java/com/demoday/ddangddangddang/domain/Rebuttal.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/Rebuttal.java
@@ -54,6 +54,10 @@ public class Rebuttal extends BaseEntity {
     private Boolean isAdopted = false; // 최종심 채택 여부
 
     @Builder.Default
+    @Column(name = "is_blind", nullable = false)
+    private Boolean isBlind = false;
+
+    @Builder.Default
     @Column(name = "case_result")
     private CaseResult caseResult = CaseResult.PENDING;
 
@@ -67,11 +71,11 @@ public class Rebuttal extends BaseEntity {
         this.likesCount = 0;
     }
 
-    public void markAsAdopted() {
-        this.isAdopted = true;
-    }
+    public void markAsAdopted() { this.isAdopted = true; }
 
     public void markAsAdoptedFalse() { this.isAdopted = false; }
+
+    public void markAsBlind() { this.isBlind = true; }
 
     public void incrementLikesCount() {
         this.likesCount++;
@@ -83,7 +87,6 @@ public class Rebuttal extends BaseEntity {
         }
     }
 
-    // 결과 업데이트 메서드
     public void updateResult(CaseResult result) {
         this.caseResult = result;
     }

--- a/src/main/java/com/demoday/ddangddangddang/dto/home/UserDefenseRebuttalResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/home/UserDefenseRebuttalResponseDto.java
@@ -24,6 +24,7 @@ public class UserDefenseRebuttalResponseDto {
         private String content;
         private int likeCount;
         private CaseResult caseResult;
+        private Boolean isBlind;
     }
 
     @Getter
@@ -38,6 +39,7 @@ public class UserDefenseRebuttalResponseDto {
         private String content;
         private int likeCount;
         private CaseResult caseResult;
+        private Boolean isBlind;
     }
 
     private List<DefenseDto> defenses;

--- a/src/main/java/com/demoday/ddangddangddang/repository/DefenseRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/DefenseRepository.java
@@ -14,14 +14,16 @@ import java.util.List;
 
 @Repository
 public interface DefenseRepository extends JpaRepository<Defense,Long>{
+    // [Fix] MyPage/본인 이력 조회를 위해 원본 메서드를 유지
     List<Defense> findDefenseByUser(User user);
 
-    // --- [ 1. 이 메서드를 추가합니다 ] ---
-    List<Defense> findAllByaCase_Id(Long caseId);
+    // --- [ 1. 이 메서드를 수정합니다 ] ---
+    // [수정] DebateService 사용. BLIND 미포함
+    List<Defense> findAllByaCase_IdAndIsBlindFalse(Long caseId);
 
-    // --- [ 2. 이 메서드를 추가합니다 ] ---
-    // 추천수 상위 N개 조회 (AI 배틀용)
-    List<Defense> findTop5ByaCase_IdOrderByLikesCountDesc(Long caseId);
+    // --- [ 2. 이 메서드를 수정합니다 ] ---
+    // [수정] 추천수 상위 N개 조회. BLIND 미포함
+    List<Defense> findTop5ByaCase_IdAndIsBlindFalseOrderByLikesCountDesc(Long caseId);
     // ---------------------------------
 
     @Modifying // (1) 이 쿼리가 DB를 수정함을 알림
@@ -32,17 +34,18 @@ public interface DefenseRepository extends JpaRepository<Defense,Long>{
     @Query("UPDATE Defense d SET d.likesCount = d.likesCount - 1 WHERE d.id = :defenseId")
     void decrementLikesCount(@Param("defenseId") Long defenseId);
 
-    //채택된 변론
-    List<Defense> findByaCase_IdAndIsAdopted(Long caseId, Boolean isAdopted);
+    // [수정] 채택된 변론. BLIND 미포함 (Fixes FinalJudgeService, AdoptService)
+    List<Defense> findByaCase_IdAndIsAdoptedAndIsBlindFalse(Long caseId, Boolean isAdopted);
 
-    //좋아요 높은 순
-    List<Defense> findAllByaCase_IdOrderByLikesCountDesc(Long caseId);
+    // [수정] 좋아요 높은 순. BLIND 미포함
+    List<Defense> findAllByaCase_IdAndIsBlindFalseOrderByLikesCountDesc(Long caseId);
 
-    //좋아요 높은 순
-    List<Defense> findTop10ByaCase_IdOrderByLikesCountDesc(Long caseId);
+    // [수정] 좋아요 높은 순 Top 10. BLIND 미포함
+    List<Defense> findTop10ByaCase_IdAndIsBlindFalseOrderByLikesCountDesc(Long caseId);
 
-    //좋아요 높은 순 + 진영
-    List<Defense> findTop5ByaCase_IdAndTypeOrderByLikesCountDesc(Long caseId, DebateSide type);
+    // [수정] 좋아요 높은 순 + 진영. BLIND 미포함
+    List<Defense> findTop5ByaCase_IdAndTypeAndIsBlindFalseOrderByLikesCountDesc(Long caseId, DebateSide type);
 
-    List<Defense> findAllByaCase_IdAndType(Long caseId, DebateSide type);
+    // [수정] 사건별 + 진영별 모든 변론. BLIND 미포함 (Fixes AdoptService, FinalJudgeService)
+    List<Defense> findAllByaCase_IdAndTypeAndIsBlindFalse(Long caseId, DebateSide type);
 }

--- a/src/main/java/com/demoday/ddangddangddang/repository/RebuttalRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/RebuttalRepository.java
@@ -33,17 +33,18 @@ public interface RebuttalRepository extends JpaRepository<Rebuttal, Long> {
     //채택된 변론
     List<Rebuttal> findByIsAdopted(Boolean isAdopted);
 
-    //사건별 채택된 변론
+    //사건별 채택된 반론
     @Query("SELECT r FROM Rebuttal r " +
-            "JOIN r.defense d " + // Rebuttal(r)과 Defense(d)를 조인
-            "WHERE d.aCase.id = :caseId AND r.isAdopted = true")
+            "JOIN r.defense d " +
+            "WHERE d.aCase.id = :caseId AND r.isAdopted = true AND r.isBlind = false") // ✨ isBlind = false 조건 추가
     List<Rebuttal> findAdoptedRebuttalsByCaseId(@Param("caseId") Long caseId);
 
     //변론당 좋아요 많은 반론
     List<Rebuttal> findByDefense_IdOrderByLikesCountDesc(Long defenseId);
 
-    //사건별 좋아요가 많은 변론 상위 10개
-    List<Rebuttal> findTop5ByDefense_aCase_IdAndTypeOrderByLikesCountDesc(Long caseId, DebateSide type);
+    //사건별 좋아요가 많은 변론 상위 5개
+    List<Rebuttal> findTop5ByDefense_aCase_IdAndTypeAndIsBlindFalseOrderByLikesCountDesc(Long caseId, DebateSide type); // ✨ 메서드 이름 수정
 
-    List<Rebuttal> findAllByDefense_aCase_IdAndType(Long caseId, DebateSide type);
+    // [수정] FinalJudgeService 사용. BLIND 미포함
+    List<Rebuttal> findAllByDefense_aCase_IdAndTypeAndIsBlindFalse(Long caseId, DebateSide type); // ✨ 메서드 이름 수정
 }

--- a/src/main/java/com/demoday/ddangddangddang/repository/ReportRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/ReportRepository.java
@@ -10,4 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface ReportRepository extends JpaRepository<Report, Long> {
     // 이미 신고했는지 확인
     boolean existsByReporterAndContentIdAndContentType(User reporter, Long contentId, ContentType contentType);
+
+    // 특정 콘텐츠의 누적 신고 횟수 조회
+    long countByContentIdAndContentType(Long contentId, ContentType contentType);
 }

--- a/src/main/java/com/demoday/ddangddangddang/service/mainpage/MainpageService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/mainpage/MainpageService.java
@@ -65,6 +65,7 @@ public class MainpageService {
         User user = userRepository.findById(userId)
                 .orElseThrow(()->new GeneralException(GeneralErrorCode.USER_NOT_FOUND,"유저를 찾을 수 없습니다."));
 
+        // [FIX] DefenseRepository에 findDefenseByUser(User user)를 다시 정의했으므로 에러 해결
         List<Defense> defenses = defenseRepository.findDefenseByUser(user);
 
         List<Rebuttal> rebuttals = rebuttalRepository.findRebuttalByUser(user);
@@ -78,6 +79,7 @@ public class MainpageService {
                         .content(defense.getContent())
                         .likeCount(defense.getLikesCount())
                         .caseResult(defense.getCaseResult())
+                        .isBlind(defense.getIsBlind())
                         .build())
                 .collect(Collectors.toList());
 
@@ -90,6 +92,7 @@ public class MainpageService {
                         .content(rebuttal.getContent())
                         .likeCount(rebuttal.getLikesCount())
                         .caseResult(rebuttal.getCaseResult())
+                        .isBlind(rebuttal.getIsBlind())
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/demoday/ddangddangddang/service/third/AdoptService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/third/AdoptService.java
@@ -47,9 +47,11 @@ public class AdoptService {
         //유저 진영 확인
         DebateSide type = userInitialArgument.getType();
 
-        List<Defense> allDefenses = defenseRepository.findAllByaCase_IdAndType(caseId,type);
+        // [FIX for error 50] BLIND 미포함 메서드 사용
+        List<Defense> allDefenses = defenseRepository.findAllByaCase_IdAndTypeAndIsBlindFalse(caseId, type);
 
-        List<Rebuttal> allRebuttals = rebuttalRepository.findAllByDefense_aCase_IdAndType(caseId,type);
+        // [RebuttalRepository의 변경도 반영 필요] BLIND 미포함 메서드 사용
+        List<Rebuttal> allRebuttals = rebuttalRepository.findAllByDefense_aCase_IdAndTypeAndIsBlindFalse(caseId, type);
 
         Stream<AdoptableItemDto> defenseStream = allDefenses.stream()
                 .map(d -> AdoptableItemDto.builder()
@@ -211,8 +213,9 @@ public class AdoptService {
         Case acase = caseRepository.findById(caseId)
                 .orElseThrow(()-> new GeneralException(GeneralErrorCode.CASE_NOT_FOUND));
 
-        List<Defense> adoptedDefenses = defenseRepository.findByaCase_IdAndIsAdopted(caseId,Boolean.TRUE);
-        List<Rebuttal> adoptedRebuttals = rebuttalRepository.findAdoptedRebuttalsByCaseId(caseId);
+        // [FIX for error 214] BLIND 미포함 메서드 사용
+        List<Defense> adoptedDefenses = defenseRepository.findByaCase_IdAndIsAdoptedAndIsBlindFalse(caseId,Boolean.TRUE);
+        List<Rebuttal> adoptedRebuttals = rebuttalRepository.findAdoptedRebuttalsByCaseId(caseId); // 이 메서드는 Repository에서 쿼리 수정됨
 
         Stream<AdoptableItemDto> defenseStream = adoptedDefenses.stream()
                 .map(d -> AdoptableItemDto.builder()


### PR DESCRIPTION
사용자 신고가 누적(5회)될 경우 변론/반론 콘텐츠를 자동 숨김 처리하는 BLIND 기능을 구현하고, 관련된 모든 도메인, API 및 조회 로직에 이 변경 사항을 반영했습니다.

상세 변경 내용
도메인 업데이트

Defense.java 및 Rebuttal.java 엔티티에 isBlind 필드(Boolean)를 추가하고, markAsBlind() 메서드를 구현했습니다.

신고 로직 강화 (임계값 5회)

ReportRepository에 countByContentIdAndContentType 메서드를 추가하여 누적 신고 횟수를 조회합니다.

ReportService 내 createReport 메서드에 임계값(5회) 로직을 추가하여, 신고 접수 시 누적 횟수가 5회 이상이면 해당 콘텐츠의 isBlind 상태를 true로 변경합니다.

Repository 조회 필터링 적용

DefenseRepository 및 RebuttalRepository의 모든 공개 조회 메서드 (예: findAllByaCase_Id, findTop5By..., findByaCase_IdAndIsAdopted)에 AndIsBlindFalse 조건을 추가하여 BLIND 처리된 콘텐츠를 모든 사용자 목록에서 제외했습니다.

서비스 로직 업데이트

DebateService 및 AdoptService, FinalJudgeService의 Defense 조회 및 반론 카운트 로직을 수정하여 BLIND 처리된 항목을 필터링하고, 변경된 Repository 메서드 이름에 맞게 코드를 수정했습니다.

MainpageService의 본인 이력 조회는 필터링하지 않으나, 변경된 DTO에 isBlind 상태를 추가하여 클라이언트에서 BLIND 여부를 확인 가능하도록 준비했습니다.

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
