### PR TITLE
[Feat] 신고 접수 시 운영자 Slack 알림 기능 추가

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/service/SlackNotificationService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/SlackNotificationService.java
@@ -1,0 +1,100 @@
+package com.demoday.ddangddangddang.service;
+
+import com.demoday.ddangddangddang.domain.Report;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SlackNotificationService {
+
+    @Value("${slack.webhook.url}")
+    private String slackWebhookUrl;
+
+    // ObjectMapper는 다른 Config(OpenAiConfig)에서 Bean으로 정의되어 있으므로 재사용
+    private final ObjectMapper objectMapper;
+
+    // Java 11+ HttpClient 사용
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * Slack Webhook으로 신고 알림을 전송합니다. (비동기)
+     */
+    public void sendReportNotification(Report report, String reporterNickname) {
+        if (slackWebhookUrl == null || slackWebhookUrl.isEmpty()) {
+            log.warn("Slack Webhook URL이 설정되지 않아 신고 알림을 건너뜁니다.");
+            return;
+        }
+
+        String messageText = buildSlackMessage(report, reporterNickname);
+
+        try {
+            // Slack 메시지 payload (JSON 형식)
+            String jsonPayload = objectMapper.writeValueAsString(Map.of("text", messageText));
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(slackWebhookUrl))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                    .build();
+
+            // 비동기로 전송하고 결과를 로그로 확인
+            httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .thenAccept(response -> {
+                        if (response.statusCode() != 200) {
+                            log.error("Slack 알림 전송 실패. 응답 코드: {}, 본문: {}", response.statusCode(), response.body());
+                        } else {
+                            log.info("Slack 알림 성공적으로 전송 완료: {}", report.getId());
+                        }
+                    })
+                    .exceptionally(e -> {
+                        log.error("Slack 알림 전송 중 예외 발생: {}", e.getMessage(), e);
+                        return null;
+                    });
+
+        } catch (IOException e) {
+            log.error("Slack 메시지 직렬화 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Slack 메시지 본문 생성 (Markdown 포맷)
+     */
+    private String buildSlackMessage(Report report, String reporterNickname) {
+        String contentInfo = String.format("%s (ID: %d)", report.getContentType().name(), report.getContentId());
+        String reasonDetail = report.getReason().getDescription();
+
+        return String.format(
+                "🚨 *새로운 콘텐츠 신고 접수* 🚨\n" +
+                        "-----------------------------------\n" +
+                        "• 신고 ID: `%d`\n" +
+                        "• 신고 콘텐츠: `%s`\n" +
+                        "• 신고자: `%s` (ID: %d)\n" +
+                        "• 신고 사유: *%s*\n" +
+                        "• 상세 사유: %s\n" +
+                        "• 접수 시각: %s\n" +
+                        "-----------------------------------",
+                report.getId(),
+                contentInfo,
+                reporterNickname,
+                report.getReporter().getId(),
+                reasonDetail,
+                report.getCustomReason() != null && !report.getCustomReason().isEmpty() ? report.getCustomReason() : "없음",
+                report.getCreatedAt() != null ? report.getCreatedAt().format(FORMATTER) : LocalDateTime.now().format(FORMATTER)
+        );
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -54,3 +54,7 @@ openai:
   client:
     connect-timeout: 10s
     read-timeout: 60s
+
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -53,3 +53,7 @@ openai:
   client:
     connect-timeout: 10s
     read-timeout: 60s
+
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}


### PR DESCRIPTION
eportService에 새로운 Slack 알림 기능을 통합하여, 사용자가 변론/반론을 신고했을 때 운영자에게 즉시 알림이 전송되도록 구현했습니다.

* **기능 추가:** SlackNotificationService를 도입하여 Slack Webhook으로 신고 정보를 비동기 전송.
* **통합:** ReportService에서 신고 저장 직후 SlackNotificationService를 호출하여 신고 내용 및 신고자 정보를 알림.
* **환경 설정:** application-prod.yml 및 application-dev.yml에 `slack.webhook.url` 설정을 추가.
* **기술 스택:** 외부 HTTP 통신을 위해 Java 11+의 기본 HttpClient 및 ObjectMapper를 활용.

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ #59 ]
