### PR TITLE
[Feat]  마감 기한 만료 사건 자동 채택 및 상태 변경 스케줄러 구현

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/global/config/SecurityConfig.java
+++ b/src/main/java/com/demoday/ddangddangddang/global/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET,"/api/v1/cases/pending").permitAll()
                 .requestMatchers(HttpMethod.GET,"/api/v1/cases/second").permitAll()
                 .requestMatchers(HttpMethod.GET,"/api/v1/cases/{caseId}","/api/v1/cases/{caseId}/defenses").permitAll()
-                .requestMatchers(HttpMethod.GET,"api/v1/defenses/{defenseId}/rebuttals").permitAll()
+                .requestMatchers(HttpMethod.GET,"/api/v1/defenses/{defenseId}/rebuttals").permitAll()
                 .requestMatchers(HttpMethod.GET,"/api/v1/cases/{caseId}/vote/result").permitAll()
                 .requestMatchers(HttpMethod.GET,"/api/v1/cases/{caseId}/debate").permitAll()
                 .requestMatchers(HttpMethod.GET,"/api/final/judge/**").permitAll()

--- a/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
@@ -5,10 +5,14 @@ import com.demoday.ddangddangddang.domain.enums.CaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 @Repository
 public interface CaseRepository extends JpaRepository<Case,Long> {
     // PENDING 상태인 사건들을 생성일자 내림차순(최신순)으로 조회
     List<Case> findAllByStatusOrderByCreatedAtDesc(CaseStatus status);
+
+    List<Case> findByAppealDeadlineBeforeAndStatus(LocalDateTime threshold, CaseStatus status);
 }

--- a/src/main/java/com/demoday/ddangddangddang/service/third/AdoptAutoScheduler.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/third/AdoptAutoScheduler.java
@@ -1,0 +1,43 @@
+package com.demoday.ddangddangddang.service.third;
+
+import com.demoday.ddangddangddang.domain.Case;
+import com.demoday.ddangddangddang.domain.enums.CaseStatus;
+import com.demoday.ddangddangddang.repository.CaseRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AdoptAutoScheduler {
+
+    private final AdoptService adoptService;
+    private final CaseRepository caseRepository;
+
+    //매일 자정마다 투표기간이 끝난지 1일이 지난 사건들을 third로 바꾸고 자동채택
+    @Scheduled(cron = "0 0 0 * * *")
+    public void autoAdoptScheduled(){
+        LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
+        List<Case> cases = caseRepository.findByAppealDeadlineBeforeAndStatus(oneDayAgo, CaseStatus.SECOND);
+        if (cases.isEmpty()) {
+            log.info("대상 사건 없음");
+            return;
+        }
+
+        for (Case aCase : cases) {
+            try {
+                // 시스템 자동 채택 수행 (내부에서 상태 변경 setThird() 포함)
+                adoptService.executeSystemAutoAdopt(aCase);
+
+                log.info("사건 ID {} 자동 채택 및 상태 변경 완료", aCase.getId());
+            } catch (Exception e) {
+                log.error("사건 ID {} 처리 중 오류 발생: {}", aCase.getId(), e.getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
- 매일 자정 마감 기한이 1일 이상 지난 사건을 조회하여 처리하는 스케줄러 추가
- 스케줄러 환경(userId 없음)에서 실행 가능하도록 AdoptService 리팩토링
  - 시스템 전용 메서드 executeSystemAutoAdopt 추가
  - 공통 채택 로직 performAutoAdoptForSide 분리하여 코드 중복 제거
- CaseRepository에 findByAppealDeadlineBefore 쿼리 메서드 추가

연관 issue #55

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [ ] 로컬테스트를 진행하셨나요?
- [ ] 머지할 브랜치를 확인하셨나요?
- [ ] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ #55 ]
