### PR TITLE
[Fix] VS 모드 대기(PENDING) 상태 상세 조회 시 500 에러 해결

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/dto/caseDto/CaseDetailResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/caseDto/CaseDetailResponseDto.java
@@ -36,6 +36,7 @@ public class CaseDetailResponseDto {
         this.status = aCase.getStatus();
         this.mode = aCase.getMode();
         this.argumentA = new ArgumentDetailDto(argA);
-        this.argumentB = new ArgumentDetailDto(argB);
+        // [수정] argB가 null이면 field도 null로 설정 (VS 모드 대기 상태 대응)
+        this.argumentB = (argB != null) ? new ArgumentDetailDto(argB) : null;
     }
 }

--- a/src/main/java/com/demoday/ddangddangddang/service/cases/CaseService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/cases/CaseService.java
@@ -212,23 +212,24 @@ public class CaseService {
         Case aCase = findCaseById(caseId);
 
         List<ArgumentInitial> arguments = argumentInitialRepository.findByaCaseOrderByTypeAsc(aCase);
-        if (arguments.size() < 2) {
+        if (arguments.isEmpty()) {
             throw new GeneralException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "데이터 오류: 입장문을 찾을 수 없습니다.");
         }
 
         ArgumentInitial argA = arguments.get(0);
-        ArgumentInitial argB = arguments.get(1);
+        // B측 입장문이 없으면 null로 처리 (PENDING 상태 대응)
+        ArgumentInitial argB = (arguments.size() > 1) ? arguments.get(1) : null;
 
         if (aCase.getMode() == CaseMode.SOLO && !argA.getUser().getId().equals(user.getId())) {
             throw new GeneralException(GeneralErrorCode.FORBIDDEN, "해당 사건에 대한 조회 권한이 없습니다.");
         }
 
-        rankingService.addCaseScore(caseId, 1.0); // 조회수 증가 로직
+        rankingService.addCaseScore(caseId, 1.0);
 
         return CaseDetailResponseDto.builder()
                 .aCase(aCase)
                 .argA(argA)
-                .argB(argB)
+                .argB(argB) // null이 들어갈 수 있음
                 .build();
     }
 


### PR DESCRIPTION
[문제 상황]
VS 모드(Party) 생성 직후 대기(PENDING) 상태에서는 A측 입장문만 존재함.
기존 상세 조회 로직이 입장문이 2개 미만일 경우 예외를 발생시켜 500 에러 발생.

[해결]
1. CaseService: 입장문 개수 검증 조건 완화 (2개 미만 -> 빈 리스트 체크). B측 입장문 부재 시 null 처리 로직 추가.
2. CaseDetailResponseDto: argB가 null일 경우 생성자에서 NPE가 발생하지 않도록 처리.

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
