### PR TITLE
[Feat] 신고 시스템 개선 (임계값 하향, 슬랙 알림 상세화, 관리자 신고 삭제 기능 추가)

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/admin/AdminReportController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/admin/AdminReportController.java
@@ -1,0 +1,25 @@
+package com.demoday.ddangddangddang.controller.admin;
+
+import com.demoday.ddangddangddang.global.apiresponse.ApiResponse;
+import com.demoday.ddangddangddang.service.report.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+@RequiredArgsConstructor
+@Tag(name = "Admin Report API", description = "운영자용 신고 관리 API - by 최우혁")
+public class AdminReportController {
+
+    private final ReportService reportService;
+
+    // TODO: 실제 운영 시에는 @PreAuthorize("hasRole('ADMIN')") 등으로 권한 체크 필요
+    @Operation(summary = "허위 신고 삭제", description = "운영자가 허위 신고로 판단한 경우 신고 내역을 삭제합니다. (삭제 후 누적 신고 수가 3회 미만이 되면 블라인드가 해제됩니다.)")
+    @DeleteMapping("/{reportId}")
+    public ApiResponse<Void> deleteFalseReport(@PathVariable Long reportId) {
+        reportService.deleteReport(reportId);
+        return ApiResponse.onSuccess("허위 신고가 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/demoday/ddangddangddang/domain/Defense.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/Defense.java
@@ -67,6 +67,9 @@ public class Defense extends BaseEntity {
 
     public void markAsBlind() { this.isBlind = true; }
 
+    // [추가] 블라인드 해제
+    public void unmarkAsBlind() { this.isBlind = false; }
+
     public void incrementLikesCount() { this.likesCount++; }
 
     public void decrementLikesCount() {

--- a/src/main/java/com/demoday/ddangddangddang/domain/Rebuttal.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/Rebuttal.java
@@ -77,6 +77,9 @@ public class Rebuttal extends BaseEntity {
 
     public void markAsBlind() { this.isBlind = true; }
 
+    // [추가] 블라인드 해제
+    public void unmarkAsBlind() { this.isBlind = false; }
+
     public void incrementLikesCount() {
         this.likesCount++;
     }

--- a/src/main/java/com/demoday/ddangddangddang/service/SlackNotificationService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/SlackNotificationService.java
@@ -24,26 +24,24 @@ public class SlackNotificationService {
     @Value("${slack.webhook.url}")
     private String slackWebhookUrl;
 
-    // ObjectMapper는 다른 Config(OpenAiConfig)에서 Bean으로 정의되어 있으므로 재사용
     private final ObjectMapper objectMapper;
-
-    // Java 11+ HttpClient 사용
     private final HttpClient httpClient = HttpClient.newHttpClient();
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     /**
      * Slack Webhook으로 신고 알림을 전송합니다. (비동기)
+     * 내용(content)과 누적 신고 수(reportCount) 파라미터 추가
      */
-    public void sendReportNotification(Report report, String reporterNickname) {
+    public void sendReportNotification(Report report, String reporterNickname, String content, long reportCount) {
         if (slackWebhookUrl == null || slackWebhookUrl.isEmpty()) {
             log.warn("Slack Webhook URL이 설정되지 않아 신고 알림을 건너뜁니다.");
             return;
         }
 
-        String messageText = buildSlackMessage(report, reporterNickname);
+        // 메시지 생성 시 content와 reportCount 전달
+        String messageText = buildSlackMessage(report, reporterNickname, content, reportCount);
 
         try {
-            // Slack 메시지 payload (JSON 형식)
             String jsonPayload = objectMapper.writeValueAsString(Map.of("text", messageText));
 
             HttpRequest request = HttpRequest.newBuilder()
@@ -52,7 +50,6 @@ public class SlackNotificationService {
                     .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
                     .build();
 
-            // 비동기로 전송하고 결과를 로그로 확인
             httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                     .thenAccept(response -> {
                         if (response.statusCode() != 200) {
@@ -73,27 +70,36 @@ public class SlackNotificationService {
 
     /**
      * Slack 메시지 본문 생성 (Markdown 포맷)
+     * 신고 내용 및 카운트 정보 추가
      */
-    private String buildSlackMessage(Report report, String reporterNickname) {
+    private String buildSlackMessage(Report report, String reporterNickname, String content, long reportCount) {
         String contentInfo = String.format("%s (ID: %d)", report.getContentType().name(), report.getContentId());
         String reasonDetail = report.getReason().getDescription();
+
+        // 내용이 너무 길면 잘라서 표시
+        String displayContent = content.length() > 100 ? content.substring(0, 100) + "..." : content;
 
         return String.format(
                 "🚨 *새로운 콘텐츠 신고 접수* 🚨\n" +
                         "-----------------------------------\n" +
                         "• 신고 ID: `%d`\n" +
-                        "• 신고 콘텐츠: `%s`\n" +
+                        "• 신고 대상: `%s`\n" +
                         "• 신고자: `%s` (ID: %d)\n" +
+                        "• 누적 신고 수: *%d회* (3회 이상 시 블라인드)\n" +
+                        "-----------------------------------\n" +
                         "• 신고 사유: *%s*\n" +
                         "• 상세 사유: %s\n" +
-                        "• 접수 시각: %s\n" +
-                        "-----------------------------------",
+                        "• 신고 내용: \n> %s\n" + // 인용구 형태로 내용 표시
+                        "-----------------------------------\n" +
+                        "• 접수 시각: %s\n",
                 report.getId(),
                 contentInfo,
                 reporterNickname,
                 report.getReporter().getId(),
+                reportCount, // 누적 신고 수
                 reasonDetail,
                 report.getCustomReason() != null && !report.getCustomReason().isEmpty() ? report.getCustomReason() : "없음",
+                displayContent, // 실제 콘텐츠 내용
                 report.getCreatedAt() != null ? report.getCreatedAt().format(FORMATTER) : LocalDateTime.now().format(FORMATTER)
         );
     }


### PR DESCRIPTION
- 신고 누적 임계값(BLIND_THRESHOLD)을 5회에서 3회로 하향 조정
- 신고 접수 시 Slack 알림에 '신고된 콘텐츠 내용'과 '누적 신고 횟수'가 포함되도록 개선 (운영자 판단 지원)
- 관리자가 허위 신고를 삭제할 수 있는 API 추가 (`DELETE /api/v1/admin/reports/{reportId}`)
- 신고 삭제 시 누적 신고 횟수가 임계값 미만으로 내려가면 자동으로 블라인드가 해제되도록 로직 구현
- Defense, Rebuttal 엔티티에 블라인드 해제 편의 메서드(`unmarkAsBlind`) 추가

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#59 ]
