### PR TITLE
[Feat] Rank Enum JSON 직렬화 시 한글 이름 반환하도록 수정

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/domain/enums/Rank.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/enums/Rank.java
@@ -1,5 +1,6 @@
 package com.demoday.ddangddangddang.domain.enums;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter
@@ -23,6 +24,7 @@ public enum Rank {
     NOVICE_BRAWLER("말싸움 하수", 100L),
     NEWBIE_BRAWLER("말싸움 풋내기", 0L);
 
+    @JsonValue
     private final String displayName;
     private final Long minExp;
 


### PR DESCRIPTION
[변경 사항]
- `Rank` Enum의 `displayName` 필드에 `@JsonValue` 어노테이션 추가
- `com.fasterxml.jackson.annotation.JsonValue` 임포트 추가

[변경 이유]
- 기존에는 `RankResponseDto` 등에서 `Rank` 타입을 반환할 때 Enum 상수명(예: `PARTNER_LAWYER`)으로 직렬화되는 문제가 있었음.
- 클라이언트에서 별도의 매핑 없이 바로 한글 등급명(예: "파트너 변호사")을 사용할 수 있도록, JSON 직렬화 시 `displayName` 값을 반환하도록 변경함.

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
