### PR TITLE
[Refactor] 핫한 재판 참여자수 반환

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/dto/home/CaseSimpleDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/home/CaseSimpleDto.java
@@ -18,4 +18,5 @@ public class CaseSimpleDto {
     private Long caseId;
     private String title;
     private List<String> mainArguments;
+    private Integer participateCnt;
 }

--- a/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
@@ -4,6 +4,8 @@ import com.demoday.ddangddangddang.domain.Case;
 import com.demoday.ddangddangddang.domain.User;
 import com.demoday.ddangddangddang.domain.enums.CaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -16,4 +18,9 @@ public interface CaseRepository extends JpaRepository<Case,Long> {
     List<Case> findAllByStatusOrderByCreatedAtDesc(CaseStatus status);
 
     List<Case> findByAppealDeadlineBeforeAndStatus(LocalDateTime threshold, CaseStatus status);
+
+    @Query("SELECT COUNT(DISTINCT u) FROM User u " +
+            "WHERE u.id IN (SELECT d.user.id FROM Defense d WHERE d.aCase.id = :caseId) " +
+            "OR u.id IN (SELECT r.user.id FROM Rebuttal r JOIN r.defense d WHERE d.aCase.id = :caseId)")
+    int countDistinctParticipants(@Param("caseId") Long caseId);
 }

--- a/src/main/java/com/demoday/ddangddangddang/service/ranking/RankingService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/ranking/RankingService.java
@@ -104,11 +104,13 @@ public class RankingService {
                     // Map에서 해당 Case의 arguments 리스트를 찾음 (없으면 빈 리스트)
                     List<String> mainArguments = argumentsMap.getOrDefault(aCase.getId(), Collections.emptyList());
 
-                    // CaseSimpleDto의 @Builder 사용
+                    int distinctCount = caseRepository.countDistinctParticipants(aCase.getId());
+
                     return CaseSimpleDto.builder()
                             .caseId(aCase.getId())
                             .title(aCase.getTitle())
                             .mainArguments(mainArguments)
+                            .participateCnt(distinctCount)
                             .build();
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
현재 핫한 사건 리스트 조회시에 변론/반론에 참여한 유저의 수를 함께 반환
변론 참여자수 U 반론 차명자수로 계산
이에 맞게 CaseSimpleDto도 수정

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [ ] 로컬테스트를 진행하셨나요?
- [ ] 머지할 브랜치를 확인하셨나요?
- [ ] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#83 ]
