### PR TITLE
[Feat] 2차 재판 상세 정보 필드 추가 및 완료된 사건 조회 API 구현

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/cases/DebateController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/cases/DebateController.java
@@ -45,13 +45,16 @@ public class DebateController {
         return ResponseEntity.ok(ApiResponse.onSuccess("2차 재판이 성공적으로 시작되었습니다."));
     }
 
-    @Operation(summary = "2차 재판 상세 정보 조회", description = "2차 재판에 필요한 모든 정보(주제, 변론, 중첩 반론, 내 투표 현황, 실시간 AI 판결)를 조회합니다.")
+    @Operation(summary = "2차 재판 상세 정보 조회", description = "2차 재판 정보(주제, 변론, 1차 입장문 등)를 조회합니다. 비로그인 유저도 조회 가능합니다.")
     @GetMapping("/cases/{caseId}/debate")
     public ResponseEntity<ApiResponse<CaseDetail2ndResponseDto>> getDebateDetails(
             @PathVariable Long caseId,
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        CaseDetail2ndResponseDto responseDto = debateService.getDebateDetails(caseId, userDetails.getUser());
+        // User 객체를 null로 넘길 수 있도록 처리
+        com.demoday.ddangddangddang.domain.User user = (userDetails != null) ? userDetails.getUser() : null;
+
+        CaseDetail2ndResponseDto responseDto = debateService.getDebateDetails(caseId, user);
         return ResponseEntity.ok(ApiResponse.onSuccess("2차 재판 정보 조회에 성공하였습니다.", responseDto));
     }
 
@@ -63,6 +66,14 @@ public class DebateController {
     public ResponseEntity<ApiResponse<List<CaseOnResponseDto>>> getSecondStageCases() {
         List<CaseOnResponseDto> responseDto = debateService.getSecondStageCases();
         return ResponseEntity.ok(ApiResponse.onSuccess("2차 재판 진행 사건 목록 조회 성공", responseDto));
+    }
+
+    // 최종판결 완료된 사건 목록 조회 (2차 재판 리스트 뷰 등에서 사용)
+    @Operation(summary = "판결 완료된 사건 목록 조회", description = "최종 판결(THIRD, DONE) 상태이지만 변론/반론 작성이 가능한 사건 목록을 조회합니다.")
+    @GetMapping("/finished")
+    public ResponseEntity<ApiResponse<List<CaseOnResponseDto>>> getFinishedCases() {
+        List<CaseOnResponseDto> responseDto = debateService.getFinishedCases();
+        return ResponseEntity.ok(ApiResponse.onSuccess("판결 완료된 사건 목록 조회 성공", responseDto));
     }
 
     @Operation(summary = "2차 재판 '변론' 목록 조회", description = "2차 재판의 모든 '변론' 목록과 각 변론의 '반론 개수'를 조회합니다.")

--- a/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/CaseDetail2ndResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/CaseDetail2ndResponseDto.java
@@ -1,5 +1,6 @@
 package com.demoday.ddangddangddang.dto.caseDto.second;
 
+import com.demoday.ddangddangddang.domain.ArgumentInitial;
 import com.demoday.ddangddangddang.domain.Case;
 import com.demoday.ddangddangddang.domain.Defense;
 import com.demoday.ddangddangddang.domain.Judgment;
@@ -24,6 +25,9 @@ public class CaseDetail2ndResponseDto {
     private List<DefenseDto> defenses;
     private VoteDto userVote; // 내가 투표한 정보 (투표 안했으면 null)
     private JudgmentResponseDto currentJudgment; // [수정] 실시간 AI 판결 결과
+
+    private ArgumentDetailDto argumentA;
+    private ArgumentDetailDto argumentB;
 
     @Getter
     @Builder
@@ -56,6 +60,23 @@ public class CaseDetail2ndResponseDto {
         private DebateSide choice;
     }
 
+    // 입장문 DTO
+    @Getter
+    @Builder
+    public static class ArgumentDetailDto {
+        private String mainArgument;
+        private String reasoning;
+        private Long authorId;
+
+        public static ArgumentDetailDto fromEntity(ArgumentInitial arg) {
+            return ArgumentDetailDto.builder()
+                    .mainArgument(arg.getMainArgument())
+                    .reasoning(arg.getReasoning())
+                    .authorId(arg.getUser().getId())
+                    .build();
+        }
+    }
+
     // 엔티티 리스트를 DTO 리스트로 변환하는 정적 팩토리 메서드
     public static CaseDetail2ndResponseDto fromEntities(
             Case aCase,
@@ -64,7 +85,10 @@ public class CaseDetail2ndResponseDto {
             Vote userVote,
             Judgment finalJudgment, // [추가] AI 판결
             Set<Long> userLikedDefenseIds,
-            Set<Long> userLikedRebuttalIds)
+            Set<Long> userLikedRebuttalIds,
+            ArgumentInitial argA,
+            ArgumentInitial argB
+            )
     {
         // 1. 모든 반론 DTO 생성
         Map<Long, RebuttalDto> rebuttalDtoMap = rebuttalList.stream()
@@ -118,7 +142,9 @@ public class CaseDetail2ndResponseDto {
                 .deadline(aCase.getAppealDeadline())
                 .defenses(defenseDtos)
                 .userVote(userVote != null ? VoteDto.builder().choice(userVote.getType()).build() : null)
-                .currentJudgment(finalJudgment != null ? new JudgmentResponseDto(finalJudgment) : null) // [수정]
+                .currentJudgment(finalJudgment != null ? new JudgmentResponseDto(finalJudgment) : null)
+                .argumentA(argA != null ? ArgumentDetailDto.fromEntity(argA) : null)
+                .argumentB(argB != null ? ArgumentDetailDto.fromEntity(argB) : null)
                 .build();
     }
 }

--- a/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
@@ -19,6 +19,9 @@ public interface CaseRepository extends JpaRepository<Case,Long> {
 
     List<Case> findByAppealDeadlineBeforeAndStatus(LocalDateTime threshold, CaseStatus status);
 
+    // 상태가 일치하고, AppealDeadline이 Null이 아닌(2차 재판을 겪은) 사건 조회
+    List<Case> findAllByStatusAndAppealDeadlineIsNotNullOrderByCreatedAtDesc(CaseStatus status);
+
     @Query("SELECT COUNT(DISTINCT u) FROM User u WHERE " +
             // 1. 변론 작성자
             "u.id IN (SELECT d.user.id FROM Defense d WHERE d.aCase.id = :caseId) OR " +


### PR DESCRIPTION
1. 2차 재판 상세 조회 (CaseDetail2ndResponseDto) 수정
   - 1차 재판의 A/B 입장문(`argumentA`, `argumentB`) 정보를 포함하도록 DTO 구조 변경
   - 비로그인(Guest) 유저가 상세 페이지 접근 시 발생하던 NPE(NullPointerException) 해결

2. 완료된 사건 리스트 조회 API 추가 (`/api/v1/cases/finished`)
   - 최종심(THIRD) 진행 중이거나 2차 재판을 거쳐 종료된(DONE) 사건 목록을 조회하는 기능 구현
   - `CaseRepository`에 항소 마감일(`appealDeadline`)이 존재하는 DONE 사건만 조회하는 쿼리 메서드 추가

3. 토론 및 권한 검증 로직 개선 (`DebateService`)
   - **조회 제한**: `FIRST` 상태(1차 재판 완료 후 대기)인 사건은 비공개 처리 (접근 시 예외 발생)
   - **작성 허용**: 최종 판결(`THIRD`) 및 종료(`DONE`) 상태에서도 변론/반론 작성이 가능하도록 상태 체크 로직 완화
   - **투표 제한**: 투표는 `SECOND` 상태에서만 가능하도록 유지

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
