### PR TITLE
[Feat] 내 정보 조회 API 응답에 userId 필드 추가

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/mypage/UserInfoUpdateController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/mypage/UserInfoUpdateController.java
@@ -31,22 +31,24 @@ public class UserInfoUpdateController {
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 정보 조회 성공",
-                        content = @Content(mediaType = "application/json",
-                                schema = @Schema(implementation = ApiResponse.class),
-                                examples = @ExampleObject(value = """
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
                     {
                       "isSuccess": true,
                       "code": "COMMON2000",
                       "message": "유저 정보 조회 성공",
                       "result": {
+                        "userId": 1,
                         "nickname": "tlsdo",
                         "profileImageUrl": "프로필 이미지",
-                        "email": "test123@naver.com"
+                        "email": "test123@naver.com",
+                        "rank": "NEWBIE_BRAWLER"
                       },
                       "error": null
                     }
                     """)))
-        })
+    })
     @GetMapping("/getInfo")
     public ApiResponse<UserResponseDto> getUserInfo(@AuthenticationPrincipal UserDetailsImpl user) {
         Long userId = user.getUser().getId();

--- a/src/main/java/com/demoday/ddangddangddang/dto/mypage/UserResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/mypage/UserResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class UserResponseDto {
+    private Long userId;
     private String nickname;
     private String email;
     private Rank rank;

--- a/src/main/java/com/demoday/ddangddangddang/service/mypage/UserInfoModifyService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/mypage/UserInfoModifyService.java
@@ -31,6 +31,7 @@ public class UserInfoModifyService {
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND,"유저를 찾을 수 없습니다."));
 
         UserResponseDto responseDto = UserResponseDto.builder()
+                .userId(user.getId())
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
                 .email(user.getEmail())


### PR DESCRIPTION
- UserResponseDto: 응답 객체에 userId 필드 추가
- UserInfoModifyService: 유저 정보 조회 시 userId 매핑 로직 추가
- UserInfoUpdateController: Swagger 문서(@ExampleObject) 예시 응답 업데이트

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
