### PR TITLE
[Fix] 2차 재판 시작 시 판결문 초기화 로직 수정 (JSON 파싱 에러 해결)

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/service/cases/DebateService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/cases/DebateService.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.Collections;
 
 @Slf4j
 @Service
@@ -74,6 +75,15 @@ public class DebateService {
         // 2차 재판 시작 시, 1차 판결문 기반으로 '최종심' 판결문 생성 (이후 계속 업데이트됨)
         Judgment initialJudgment = judgmentRepository.findByaCase_IdAndStage(caseId, JudgmentStage.INITIAL)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "1차 판결문이 없습니다."));
+
+        // 1차 판결문의 텍스트(basedOn)를 그대로 복사하지 않고, 빈 JSON 구조를 넣어줍니다.
+        JudgementBasisDto emptyBasis = new JudgementBasisDto(Collections.emptyList(), Collections.emptyList());
+        String emptyBasisJson;
+        try {
+            emptyBasisJson = objectMapper.writeValueAsString(emptyBasis);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("초기 설정 중 JSON 변환 오류", e);
+        }
 
         Judgment finalJudgment = Judgment.builder()
                 .aCase(foundCase)


### PR DESCRIPTION
- DebateService: startAppeal 메서드에서 2차 판결문(FINAL) 생성 시, 1차 판결문의 basedOn(String)을 그대로 복사하던 문제를 수정
- 조회 API(getFinalJudgemnet)가 basedOn 필드를 JSON으로 파싱하므로, 초기값으로 빈 JSON 객체({"defenseIds":[], "rebuttalIds":[]})를 설정하도록 변경
- 이를 통해 2차 재판 시작 직후 판결문 조회 시 발생하는 'Failed to parse judgment basis' 500 에러 해결

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
