### PR TITLE
[Feat] 변론 및 반론 조회 시 작성자 칭호(Rank) 필드 추가

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/CaseDetail2ndResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/CaseDetail2ndResponseDto.java
@@ -34,6 +34,7 @@ public class CaseDetail2ndResponseDto {
     public static class DefenseDto {
         private Long defenseId;
         private String authorNickname;
+        private String authorRank;
         private DebateSide side;
         private String content;
         private Integer likesCount;
@@ -47,6 +48,7 @@ public class CaseDetail2ndResponseDto {
         private Long rebuttalId;
         private Long parentId; // 부모 반론 ID (대댓글용)
         private String authorNickname;
+        private String authorRank;
         private DebateSide type;
         private String content;
         private Integer likesCount;
@@ -96,6 +98,7 @@ public class CaseDetail2ndResponseDto {
                         .rebuttalId(rebuttal.getId())
                         .parentId(rebuttal.getParent() != null ? rebuttal.getParent().getId() : null)
                         .authorNickname(rebuttal.getUser().getNickname())
+                        .authorRank(rebuttal.getUser().getRank().getDisplayName())
                         .type(rebuttal.getType())
                         .content(rebuttal.getContent())
                         .likesCount(rebuttal.getLikesCount())
@@ -127,6 +130,7 @@ public class CaseDetail2ndResponseDto {
                 .map(defense -> DefenseDto.builder()
                         .defenseId(defense.getId())
                         .authorNickname(defense.getUser().getNickname())
+                        .authorRank(defense.getUser().getRank().getDisplayName())
                         .side(defense.getType())
                         .content(defense.getContent())
                         .likesCount(defense.getLikesCount())

--- a/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/DefenseResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/DefenseResponseDto.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class DefenseResponseDto {
     private Long defenseId;
     private String authorNickname;
+    private String authorRank;
     private DebateSide side;
     private String content;
     private Integer likesCount;
@@ -20,6 +21,7 @@ public class DefenseResponseDto {
         return DefenseResponseDto.builder()
                 .defenseId(defense.getId())
                 .authorNickname(defense.getUser().getNickname())
+                .authorRank(defense.getUser().getRank().getDisplayName())
                 .side(defense.getType())
                 .content(defense.getContent())
                 .likesCount(defense.getLikesCount())

--- a/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/RebuttalResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/RebuttalResponseDto.java
@@ -17,6 +17,7 @@ public class RebuttalResponseDto {
     private Long rebuttalId;
     private Long parentId; // 부모 반론 ID (대댓글용)
     private String authorNickname;
+    private String authorRank;
     private DebateSide type;
     private String content;
     private Integer likesCount;
@@ -32,6 +33,7 @@ public class RebuttalResponseDto {
                         .rebuttalId(rebuttal.getId())
                         .parentId(rebuttal.getParent() != null ? rebuttal.getParent().getId() : null)
                         .authorNickname(rebuttal.getUser().getNickname())
+                        .authorRank(rebuttal.getUser().getRank().getDisplayName())
                         .type(rebuttal.getType())
                         .content(rebuttal.getContent())
                         .likesCount(rebuttal.getLikesCount())


### PR DESCRIPTION
- DefenseResponseDto, RebuttalResponseDto, CaseDetail2ndResponseDto에 authorRank 필드 추가
- 2차 재판 상세 조회 및 변론/반론 목록 조회 API 호출 시 작성자의 칭호(예: "변호사 1단계")를 함께 반환하도록 수정

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
