### PR TITLE
[Fix] 비로그인 유저의 변론 및 반론 조회 시 발생하는 500 에러 수정

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/cases/DebateController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/cases/DebateController.java
@@ -82,7 +82,11 @@ public class DebateController {
             @PathVariable Long caseId,
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        List<DefenseResponseDto> responseDto = debateService.getDefensesByCase(caseId, userDetails.getUser());
+        // 비로그인(null) 처리 추가
+        com.demoday.ddangddangddang.domain.User user = (userDetails != null) ? userDetails.getUser() : null;
+
+        // user 객체 전달
+        List<DefenseResponseDto> responseDto = debateService.getDefensesByCase(caseId, user);
         return ResponseEntity.ok(ApiResponse.onSuccess("변론 목록 조회에 성공하였습니다.", responseDto));
     }
 
@@ -92,7 +96,11 @@ public class DebateController {
             @PathVariable Long defenseId,
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        List<RebuttalResponseDto> responseDto = debateService.getRebuttalsByDefense(defenseId, userDetails.getUser());
+        // 비로그인(null) 처리 추가
+        com.demoday.ddangddangddang.domain.User user = (userDetails != null) ? userDetails.getUser() : null;
+
+        // user 객체 전달
+        List<RebuttalResponseDto> responseDto = debateService.getRebuttalsByDefense(defenseId, user);
         return ResponseEntity.ok(ApiResponse.onSuccess("반론 목록 조회에 성공하였습니다.", responseDto));
     }
 


### PR DESCRIPTION
- DebateController: getDefensesByCase, getRebuttalsByDefense 요청 시 인증 정보(userDetails)가 없으면 발생하는 NullPointerException 해결
- 비로그인 유저일 경우 서비스 계층으로 null을 전달하여, 로그인 여부와 관계없이 목록을 조회할 수 있도록 수정

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
