### PR TITLE
[Feat] 경험치 내역(ExpLog) 조회 기능 구현 및 지급 로직 리팩토링

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/mypage/MypageController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/mypage/MypageController.java
@@ -7,6 +7,7 @@ import com.demoday.ddangddangddang.dto.mypage.UserAchievementResponseDto;
 import com.demoday.ddangddangddang.dto.mypage.UserArchiveResponseDto;
 import com.demoday.ddangddangddang.global.apiresponse.ApiResponse;
 import com.demoday.ddangddangddang.service.mypage.MypageService;
+import com.demoday.ddangddangddang.dto.mypage.ExpHistoryResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -29,6 +30,41 @@ import java.util.List;
 @SecurityRequirement(name = "JWT TOKEN")
 public class MypageController {
     private final MypageService mypageService;
+
+    @Operation(summary = "경험치 내역 조회", description = "로그인한 유저의 경험치 획득/차감 내역을 조회합니다. - by 최우혁")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "경험치 내역 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value =
+                                    "{\n" +
+                                            "  \"isSuccess\": true,\n" +
+                                            "  \"code\": \"COMMON2000\",\n" +
+                                            "  \"message\": \"경험치 내역 조회 성공\",\n" +
+                                            "  \"result\": [\n" +
+                                            "    {\n" +
+                                            "      \"id\": 10,\n" +
+                                            "      \"amount\": 150,\n" +
+                                            "      \"description\": \"재판 승리\",\n" +
+                                            "      \"createdAt\": \"2025-11-24 14:00:00\"\n" +
+                                            "    },\n" +
+                                            "    {\n" +
+                                            "      \"id\": 9,\n" +
+                                            "      \"amount\": 50,\n" +
+                                            "      \"description\": \"변론 작성\",\n" +
+                                            "      \"createdAt\": \"2025-11-24 13:30:00\"\n" +
+                                            "    }\n" +
+                                            "  ],\n" +
+                                            "  \"error\": null\n" +
+                                            "}")
+                    )
+            )
+    })
+    @GetMapping("/exp-history")
+    public ApiResponse<List<ExpHistoryResponseDto>> getExpHistory(@AuthenticationPrincipal(expression = "user") User user) {
+        Long userId = user.getId();
+        return mypageService.getExpHistory(userId);
+    }
 
     //로그인 및 스프링 세큐리티 구현 완료 후 파라미터 변경 예정 -완료-
     @Operation(summary = "유저 등급(랭크) 조회", description = "로그인한 유저의 현재 등급, 경험치, 랭크 이름을 조회합니다.")

--- a/src/main/java/com/demoday/ddangddangddang/domain/ExpLog.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/ExpLog.java
@@ -1,0 +1,33 @@
+package com.demoday.ddangddangddang.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "exp_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExpLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "exp_log_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount; // 획득/차감량 (예: +100, -50)
+
+    @Column(name = "description", nullable = false)
+    private String description; // 변동 사유 (예: "사건 승리", "변론 작성")
+
+    @Builder
+    public ExpLog(User user, Long amount, String description) {
+        this.user = user;
+        this.amount = amount;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/demoday/ddangddangddang/dto/mypage/ExpHistoryResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/mypage/ExpHistoryResponseDto.java
@@ -1,0 +1,18 @@
+package com.demoday.ddangddangddang.dto.mypage;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ExpHistoryResponseDto {
+    private Long id;
+    private Long amount;
+    private String description;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/demoday/ddangddangddang/repository/ExpLogRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/ExpLogRepository.java
@@ -1,0 +1,11 @@
+package com.demoday.ddangddangddang.repository;
+
+import com.demoday.ddangddangddang.domain.ExpLog;
+import com.demoday.ddangddangddang.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ExpLogRepository extends JpaRepository<ExpLog, Long> {
+    // 특정 유저의 경험치 내역을 생성일자 내림차순(최신순)으로 조회
+    List<ExpLog> findAllByUserOrderByCreatedAtDesc(User user);
+}

--- a/src/main/java/com/demoday/ddangddangddang/service/ExpService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/ExpService.java
@@ -1,0 +1,29 @@
+package com.demoday.ddangddangddang.service;
+
+import com.demoday.ddangddangddang.domain.ExpLog;
+import com.demoday.ddangddangddang.domain.User;
+import com.demoday.ddangddangddang.repository.ExpLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ExpService {
+    private final ExpLogRepository expLogRepository;
+
+    // 이 메서드를 user.addExp() 대신 사용하세요
+    public void addExp(User user, Long amount, String description) {
+        // 1. 실제 유저 경험치 증가
+        user.addExp(amount);
+
+        // 2. 내역 저장
+        ExpLog log = ExpLog.builder()
+                .user(user)
+                .amount(amount)
+                .description(description)
+                .build();
+        expLogRepository.save(log);
+    }
+}

--- a/src/main/java/com/demoday/ddangddangddang/service/LikeService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/LikeService.java
@@ -28,6 +28,7 @@ public class LikeService {
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final RankingService rankingService;
+    private final ExpService expService;
 
     /**
      * 변론 / 반론 좋아요 토글
@@ -56,14 +57,14 @@ public class LikeService {
                 defense.decrementLikesCount();
                 caseIdToUpdate = defense.getACase().getId();
                 rankingService.addCaseScore(caseIdToUpdate, -3.0);
-                defense.getUser().addExp(-5L);
+                expService.addExp(defense.getUser(), -5L, "변론 좋아요 취소됨");
             } else {
                 Rebuttal rebuttal = rebuttalRepository.findById(contentId)
                         .orElseThrow(() -> new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "반론을 찾을 수 없습니다."));
                 rebuttal.decrementLikesCount();
                 caseIdToUpdate = rebuttal.getDefense().getACase().getId();
                 rankingService.addCaseScore(caseIdToUpdate, -3.0);
-                rebuttal.getUser().addExp(-5L);
+                expService.addExp(rebuttal.getUser(), -5L, "반론 좋아요 취소됨");
             }
 
             isLiked = false;
@@ -83,7 +84,7 @@ public class LikeService {
                 defense.incrementLikesCount();
                 caseIdToUpdate = defense.getACase().getId();
                 rankingService.addCaseScore(caseIdToUpdate,3.0);
-                defense.getUser().addExp(5L);
+                expService.addExp(defense.getUser(), 5L, "변론 좋아요 받음");
                 eventPublisher.publishEvent(new LikedEvent(defense.getUser()));
             } else {
                 Rebuttal rebuttal = rebuttalRepository.findById(contentId)
@@ -91,7 +92,7 @@ public class LikeService {
                 rebuttal.incrementLikesCount();
                 caseIdToUpdate = rebuttal.getDefense().getACase().getId();
                 rankingService.addCaseScore(caseIdToUpdate,3.0);
-                rebuttal.getUser().addExp(5L);
+                expService.addExp(rebuttal.getUser(), 5L, "반론 좋아요 받음");
                 eventPublisher.publishEvent(new LikedEvent(rebuttal.getUser()));
             }
 

--- a/src/main/java/com/demoday/ddangddangddang/service/cases/CaseService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/cases/CaseService.java
@@ -17,6 +17,7 @@ import com.demoday.ddangddangddang.repository.CaseRepository;
 import com.demoday.ddangddangddang.repository.JudgmentRepository;
 import com.demoday.ddangddangddang.repository.CaseParticipationRepository; // [추가]
 import com.demoday.ddangddangddang.service.ChatGptService;
+import com.demoday.ddangddangddang.service.ExpService;
 import com.demoday.ddangddangddang.service.ranking.RankingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +42,7 @@ public class CaseService {
     private final RankingService rankingService;
     private final SseEmitters sseEmitters;
     private final ApplicationEventPublisher eventPublisher;
+    private final ExpService expService;
 
     @Transactional
     public CaseResponseDto createCase(CaseRequestDto requestDto, User user) {
@@ -138,7 +140,7 @@ public class CaseService {
                 .result(CaseResult.PENDING).build());
 
         // VS 모드 사건 생성 시 +100 exp
-        user.addExp(100L);
+        expService.addExp(user, 100L, "VS 모드 사건 생성");
 
         //이벤트 리스너 호출(사건 생성)
         eventPublisher.publishEvent(new CaseCreatedEvent(user));

--- a/src/main/java/com/demoday/ddangddangddang/service/mypage/MypageService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/mypage/MypageService.java
@@ -14,6 +14,9 @@ import com.demoday.ddangddangddang.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.demoday.ddangddangddang.domain.ExpLog;
+import com.demoday.ddangddangddang.dto.mypage.ExpHistoryResponseDto;
+import com.demoday.ddangddangddang.repository.ExpLogRepository;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +35,27 @@ public class MypageService {
     private final CaseParticipationRepository caseParticipationRepository;
     private final ArgumentInitialRepository argumentInitialRepository;
     private final UserAchievementRepository userAchievementRepository;
+    private final ExpLogRepository expLogRepository;
+
+    // 경험치 히스토리 조회 메서드 추가
+    @Transactional(readOnly = true)
+    public ApiResponse<List<ExpHistoryResponseDto>> getExpHistory(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND, "유저를 찾을 수 없습니다."));
+
+        List<ExpLog> logs = expLogRepository.findAllByUserOrderByCreatedAtDesc(user);
+
+        List<ExpHistoryResponseDto> responseDtos = logs.stream()
+                .map(log -> ExpHistoryResponseDto.builder()
+                        .id(log.getId())
+                        .amount(log.getAmount())
+                        .description(log.getDescription())
+                        .createdAt(log.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ApiResponse.onSuccess("경험치 내역 조회 성공", responseDtos);
+    }
 
     public ApiResponse<RankResponseDto> getRank(Long userId) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/demoday/ddangddangddang/service/third/AdoptService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/third/AdoptService.java
@@ -12,6 +12,7 @@ import com.demoday.ddangddangddang.global.apiresponse.ApiResponse;
 import com.demoday.ddangddangddang.global.code.GeneralErrorCode;
 import com.demoday.ddangddangddang.global.exception.GeneralException;
 import com.demoday.ddangddangddang.repository.*;
+import com.demoday.ddangddangddang.service.ExpService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -31,6 +32,7 @@ public class AdoptService {
     private final UserRepository userRepository;
     private final ArgumentInitialRepository argumentInitialRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final ExpService expService;
 
     //좋아요 많은 순으로 노출 (유저가 채택화면에서 보게 될 선택지)
     public ApiResponse<AdoptResponseDto> getOpinionBest(Long userId, Long caseId) {
@@ -165,7 +167,7 @@ public class AdoptService {
 
                     // ★ 수정 모드가 아닐 때(최초 채택일 때)만 경험치 지급
                     if (!isEditMode) {
-                        defense.getUser().addExp(100L);
+                        expService.addExp(defense.getUser(), 100L, "변론 채택됨 (작성자)");
                         eventPublisher.publishEvent(new AdoptedEvent(defense.getUser(), ContentType.DEFENSE));
                     }
                 }
@@ -182,7 +184,7 @@ public class AdoptService {
 
                     // ★ 수정 모드가 아닐 때(최초 채택일 때)만 경험치 지급
                     if (!isEditMode) {
-                        rebuttal.getUser().addExp(100L);
+                        expService.addExp(rebuttal.getUser(), 100L, "반론 채택됨 (작성자)");
                         eventPublisher.publishEvent(new AdoptedEvent(rebuttal.getUser(), ContentType.REBUTTAL));
                     }
                 }
@@ -273,7 +275,7 @@ public class AdoptService {
                     // 이미 채택된 경우 중복 처리 방지 (옵션)
                     if (!Boolean.TRUE.equals(defense.getIsAdopted())) {
                         defense.markAsAdopted();
-                        defense.getUser().addExp(100L);
+                        expService.addExp(defense.getUser(), 100L, "변론 자동 채택");
                         eventPublisher.publishEvent(new AdoptedEvent(defense.getUser(),ContentType.DEFENSE));
                     }
                 });
@@ -281,7 +283,7 @@ public class AdoptService {
                 rebuttalRepository.findById(item.getId()).ifPresent(rebuttal -> {
                     if (!Boolean.TRUE.equals(rebuttal.getIsAdopted())) {
                         rebuttal.markAsAdopted();
-                        rebuttal.getUser().addExp(100L);
+                        expService.addExp(rebuttal.getUser(), 100L, "반론 자동 채택");
                         eventPublisher.publishEvent(new AdoptedEvent(rebuttal.getUser(),ContentType.REBUTTAL));
                     }
                 });

--- a/src/main/java/com/demoday/ddangddangddang/service/third/FinalJudgeService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/third/FinalJudgeService.java
@@ -11,6 +11,7 @@ import com.demoday.ddangddangddang.global.code.GeneralErrorCode;
 import com.demoday.ddangddangddang.global.exception.GeneralException;
 import com.demoday.ddangddangddang.repository.*;
 import com.demoday.ddangddangddang.service.ChatGptService;
+import com.demoday.ddangddangddang.service.ExpService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
@@ -41,6 +42,7 @@ public class FinalJudgeService {
     private final VoteRepository voteRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final ExpService expService;
 
     /**
      * 1. [ReadOnly Transaction] 판결에 필요한 데이터를 미리 조회
@@ -131,7 +133,7 @@ public class FinalJudgeService {
                 if (argumentInitial.getType() == winSide) {
                     caseParticipation.updateResult(CaseResult.WIN);
                     eventPublisher.publishEvent(new WinEvent(user));
-                    caseParticipation.getUser().addExp(150L);
+                    expService.addExp(caseParticipation.getUser(), 150L, "최종 판결 승소 (사건 당사자)");
                     caseParticipation.getUser().updateWin();
                 } else if (winSide == DebateSide.DRAW) {
                     caseParticipation.updateResult(CaseResult.DRAW);
@@ -146,7 +148,7 @@ public class FinalJudgeService {
         for (Defense adoptDefense : adoptedDefenses) {
             if (adoptDefense.getType() == winSide) {
                 adoptDefense.updateResult(CaseResult.WIN);
-                adoptDefense.getUser().addExp(150L);
+                expService.addExp(adoptDefense.getUser(), 150L, "채택된 변론 승소");
                 adoptDefense.getUser().updateWin();
                 eventPublisher.publishEvent(new WinEvent(adoptDefense.getUser()));
             } else if (winSide == DebateSide.DRAW) {
@@ -160,7 +162,7 @@ public class FinalJudgeService {
         for (Rebuttal adoptedRebuttal : adoptedRebuttals) {
             if (adoptedRebuttal.getType() == winSide) {
                 adoptedRebuttal.updateResult(CaseResult.WIN);
-                adoptedRebuttal.getUser().addExp(150L);
+                expService.addExp(adoptedRebuttal.getUser(), 150L, "채택된 반론 승소");
                 adoptedRebuttal.getUser().updateWin();
                 eventPublisher.publishEvent(new WinEvent(adoptedRebuttal.getUser()));
             } else if (winSide == DebateSide.DRAW) {
@@ -175,7 +177,7 @@ public class FinalJudgeService {
         if (winSide != DebateSide.DRAW) {
             List<Vote> winVotes = voteRepository.findByaCase_IdAndType(foundCase.getId(), winSide);
             for (Vote winVote : winVotes) {
-                winVote.getUser().addExp(20L);
+                expService.addExp(winVote.getUser(), 20L, "승리 진영 투표 적중");
             }
         }
     }


### PR DESCRIPTION
- 경험치 변동 내역 저장을 위한 ExpLog 엔티티 및 Repository 생성
- 마이페이지 경험치 히스토리 조회 API 추가 (GET /api/users/exp-history)
- ExpService 도입: 경험치 지급(addExp)과 로그 저장을 하나의 트랜잭션으로 캡슐화
- 기존 서비스(Case, Debate, FinalJudge, Adopt, Like)의 경험치 지급 로직을 ExpService 사용으로 전면 교체

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#46 ]
