### PR TITLE
[Fix] 2차 재판 시작 시 deadline 필수값 검증 로직 추가

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/domain/Case.java
+++ b/src/main/java/com/demoday/ddangddangddang/domain/Case.java
@@ -56,8 +56,11 @@ public class Case extends BaseEntity {
         }
     }
 
-    // --- [ startAppeal 메서드 수정: deadline 파라미터 제거 ] ---
+    // --- [ startAppeal 메서드 수정: deadline null 체크 추가 ] ---
     public void startAppeal(LocalDateTime deadline) {
+        if (deadline == null) {
+            throw new IllegalArgumentException("2차 재판 마감 기한(deadline)은 필수입니다.");
+        }
         this.status = CaseStatus.SECOND;
         this.appealDeadline = deadline;
     }


### PR DESCRIPTION
- Case 엔티티의 startAppeal 메서드 호출 시 deadline이 null이면 IllegalArgumentException 발생하도록 수정
- 2차 재판 상태 변경 시 마감 기한 설정을 강제하여 데이터 무결성 보장

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]
