### PR TITLE
[Feat] 블라인드 게시글 조회 시 '블라인드 처리된 내용입니다' 문구로 마스킹하여 반환

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/CaseDetail2ndResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/CaseDetail2ndResponseDto.java
@@ -127,16 +127,21 @@ public class CaseDetail2ndResponseDto {
 
         // 4. 변론 DTO 생성
         List<DefenseDto> defenseDtos = defenseList.stream()
-                .map(defense -> DefenseDto.builder()
-                        .defenseId(defense.getId())
-                        .authorNickname(defense.getUser().getNickname())
-                        .authorRank(defense.getUser().getRank().getDisplayName())
-                        .side(defense.getType())
-                        .content(defense.getContent())
-                        .likesCount(defense.getLikesCount())
-                        .isLikedByMe(userLikedDefenseIds.contains(defense.getId()))
-                        .rebuttals(topLevelRebuttalsByDefenseId.getOrDefault(defense.getId(), List.of()))
-                        .build())
+                .map(defense -> {
+                    // [수정]
+                    String content = defense.getIsBlind() ? "블라인드 처리된 내용입니다." : defense.getContent();
+
+                    return DefenseDto.builder()
+                            .defenseId(defense.getId())
+                            .authorNickname(defense.getUser().getNickname())
+                            .authorRank(defense.getUser().getRank().getDisplayName())
+                            .side(defense.getType())
+                            .content(content) // 마스킹
+                            .likesCount(defense.getLikesCount())
+                            .isLikedByMe(userLikedDefenseIds.contains(defense.getId()))
+                            .rebuttals(topLevelRebuttalsByDefenseId.getOrDefault(defense.getId(), List.of()))
+                            .build();
+                })
                 .collect(Collectors.toList());
 
         // 5. 최종 DTO 빌드

--- a/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/DefenseResponseDto.java
+++ b/src/main/java/com/demoday/ddangddangddang/dto/caseDto/second/DefenseResponseDto.java
@@ -17,18 +17,23 @@ public class DefenseResponseDto {
     private Integer likesCount;
     private Boolean isLikedByMe;
     private long rebuttalCount; // 이 변론에 달린 반론(대댓글)의 총 개수
+    private Boolean isBlind;
 
     public static DefenseResponseDto fromEntity(Defense defense, boolean isLikedByMe, long rebuttalCount) {
+        // 블라인드 여부에 따른 콘텐츠 마스킹 로직
+        String displayContent = defense.getIsBlind() ? "블라인드 처리된 내용입니다." : defense.getContent();
+
         return DefenseResponseDto.builder()
                 .defenseId(defense.getId())
                 .authorNickname(defense.getUser().getNickname())
                 .authorProfileUrl(defense.getUser().getProfileImageUrl())
                 .authorRank(defense.getUser().getRank().getDisplayName())
                 .side(defense.getType())
-                .content(defense.getContent())
+                .content(displayContent) // 마스킹된 내용 주입
                 .likesCount(defense.getLikesCount())
                 .isLikedByMe(isLikedByMe)
                 .rebuttalCount(rebuttalCount)
+                .isBlind(defense.getIsBlind()) // 상태값 추가
                 .build();
     }
 }

--- a/src/main/java/com/demoday/ddangddangddang/repository/DefenseRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/DefenseRepository.java
@@ -18,8 +18,8 @@ public interface DefenseRepository extends JpaRepository<Defense,Long>{
     // MyPage/본인 이력 조회를 위해 원본 메서드를 유지
     List<Defense> findDefenseByUser(User user);
 
-    // DebateService 사용. BLIND 미포함
-    List<Defense> findAllByaCase_IdAndIsBlindFalse(Long caseId);
+    // 토론장 조회를 위해 블라인드 여부 상관없이 모두 가져오는 메서드 추가
+    List<Defense> findAllByaCase_Id(Long caseId);
 
     // 추천수 상위 N개 조회. BLIND 미포함
     List<Defense> findTop5ByaCase_IdAndIsBlindFalseOrderByLikesCountDesc(Long caseId);

--- a/src/main/java/com/demoday/ddangddangddang/service/mainpage/MainpageService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/mainpage/MainpageService.java
@@ -65,35 +65,43 @@ public class MainpageService {
         User user = userRepository.findById(userId)
                 .orElseThrow(()->new GeneralException(GeneralErrorCode.USER_NOT_FOUND,"유저를 찾을 수 없습니다."));
 
-        // [FIX] DefenseRepository에 findDefenseByUser(User user)를 다시 정의했으므로 에러 해결
         List<Defense> defenses = defenseRepository.findDefenseByUser(user);
-
         List<Rebuttal> rebuttals = rebuttalRepository.findRebuttalByUser(user);
 
         List<UserDefenseRebuttalResponseDto.DefenseDto> defenseDtos = defenses.stream()
-                .map(defense -> UserDefenseRebuttalResponseDto.DefenseDto.builder()
-                        .caseId(defense.getACase().getId())
-                        .title(defense.getACase().getTitle())
-                        .defenseId(defense.getId())
-                        .debateSide(defense.getType())
-                        .content(defense.getContent())
-                        .likeCount(defense.getLikesCount())
-                        .caseResult(defense.getCaseResult())
-                        .isBlind(defense.getIsBlind())
-                        .build())
+                .map(defense -> {
+                    // [수정] 마이페이지에서도 블라인드 처리된 내용 표시
+                    String content = defense.getIsBlind() ? "블라인드 처리된 내용입니다." : defense.getContent();
+
+                    return UserDefenseRebuttalResponseDto.DefenseDto.builder()
+                            .caseId(defense.getACase().getId())
+                            .title(defense.getACase().getTitle())
+                            .defenseId(defense.getId())
+                            .debateSide(defense.getType())
+                            .content(content) // 마스킹 적용
+                            .likeCount(defense.getLikesCount())
+                            .caseResult(defense.getCaseResult())
+                            .isBlind(defense.getIsBlind())
+                            .build();
+                })
                 .collect(Collectors.toList());
 
         List<UserDefenseRebuttalResponseDto.RebuttalDto> rebuttalDtos = rebuttals.stream()
-                .map(rebuttal -> UserDefenseRebuttalResponseDto.RebuttalDto.builder()
-                        .caseId(rebuttal.getDefense().getACase().getId())
-                        .defenseId(rebuttal.getId())
-                        .rebuttalId(rebuttal.getId())
-                        .debateSide(rebuttal.getType())
-                        .content(rebuttal.getContent())
-                        .likeCount(rebuttal.getLikesCount())
-                        .caseResult(rebuttal.getCaseResult())
-                        .isBlind(rebuttal.getIsBlind())
-                        .build())
+                .map(rebuttal -> {
+                    // [수정] 마이페이지에서도 블라인드 처리된 내용 표시
+                    String content = rebuttal.getIsBlind() ? "블라인드 처리된 내용입니다." : rebuttal.getContent();
+
+                    return UserDefenseRebuttalResponseDto.RebuttalDto.builder()
+                            .caseId(rebuttal.getDefense().getACase().getId())
+                            .defenseId(rebuttal.getId())
+                            .rebuttalId(rebuttal.getId())
+                            .debateSide(rebuttal.getType())
+                            .content(content) // 마스킹 적용
+                            .likeCount(rebuttal.getLikesCount())
+                            .caseResult(rebuttal.getCaseResult())
+                            .isBlind(rebuttal.getIsBlind())
+                            .build();
+                })
                 .collect(Collectors.toList());
 
         UserDefenseRebuttalResponseDto responseDto = UserDefenseRebuttalResponseDto.builder()


### PR DESCRIPTION
기존에 블라인드 처리된 변론 및 반론이 조회되지 않던 로직을 개선하여,
리스트에는 노출되되 내용은 안내 문구로 대체되어 반환되도록 수정했습니다.

[변경 사항]
1. DTO 수정 (DefenseResponseDto, RebuttalResponseDto)
   - isBlind가 true일 경우 content를 "블라인드 처리된 내용입니다."로 대체하는 로직 추가
   - 프론트엔드 상태 처리를 위해 isBlind 필드 추가

2. Service 수정 (DebateService, MainpageService)
   - 게시글 조회 시 블라인드 필터링(isBlindFalse) 조건 제거
   - DefenseRepository의 findAllByaCase_Id 등 전체 조회 메서드 사용

3. Repository 수정 (DefenseRepository)
   - 사건 ID로 블라인드 여부와 관계없이 모든 변론을 조회하는 메서드 추가

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#117 ]
