### PR TITLE
[Feat] 사건(Case) 제목 검색 API 및 비즈니스 로직 구현

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/controller/cases/CaseController.java
+++ b/src/main/java/com/demoday/ddangddangddang/controller/cases/CaseController.java
@@ -27,7 +27,17 @@ public class CaseController {
 
     private final CaseService caseService;
 
-    // --- [ 1차 재판 API (기존) ] ---
+    // --- [ 1차 재판 API ] ---
+
+    // 사건 검색 API
+    @Operation(summary = "사건 검색", description = "제목에 포함된 키워드로 사건을 검색합니다. (최신순 정렬)")
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<CaseOnResponseDto>>> searchCases(
+            @RequestParam(name = "keyword") String keyword
+    ) {
+        List<CaseOnResponseDto> responseDto = caseService.searchCases(keyword);
+        return ResponseEntity.ok(ApiResponse.onSuccess("사건 검색 성공", responseDto));
+    }
 
     @Operation(summary = "1차 재판(초심) 생성 (솔로/VS 모드)", description = "mode: SOLO(솔로), PARTY(VS모드)")
     @SecurityRequirement(name = "JWT TOKEN")

--- a/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/CaseRepository.java
@@ -21,6 +21,9 @@ public interface CaseRepository extends JpaRepository<Case,Long> {
 
     List<Case> findByAppealDeadlineBeforeAndStatus(LocalDateTime threshold, CaseStatus status);
 
+    // 제목에 키워드가 포함된 사건 검색 (최신순 정렬)
+    List<Case> findByTitleContainingOrderByCreatedAtDesc(String keyword);
+
     // 상태가 일치하고, AppealDeadline이 Null이 아닌(2차 재판을 겪은) 사건 조회
     List<Case> findAllByStatusAndAppealDeadlineIsNotNullOrderByCreatedAtDesc(CaseStatus status);
 


### PR DESCRIPTION
- CaseRepository: 제목 키워드 포함 검색 및 최신순 정렬 쿼리 메서드 추가 (findByTitleContainingOrderByCreatedAtDesc)
- CaseService:
  - 검색 비즈니스 로직 구현 (searchCases)
  - 엔티티 -> DTO 변환 헬퍼 메서드 추가 (convertToDto)
- CaseController: 사건 검색 API 엔드포인트 추가 (GET /api/v1/cases/search)

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#120 ]
