### PR TITLE
[Fix] 2차 재판 상세 조회 시 중복 데이터로 인한 500 에러 해결

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/repository/VoteRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/VoteRepository.java
@@ -11,10 +11,8 @@ import java.util.Optional;
 
 @Repository
 public interface VoteRepository extends JpaRepository<Vote,Long> {
-    // --- [ 1. 이 메서드들을 추가합니다 ] ---
-
-    // 사용자와 사건 ID로 투표 기록 조회 (중복 투표 방지 및 수정용)
-    Optional<Vote> findByaCase_IdAndUser_Id(Long caseId, Long userId);
+    // 최신 투표 내역 1건만 조회
+    Optional<Vote> findTopByaCase_IdAndUser_IdOrderByVotedAtDesc(Long caseId, Long userId);
 
     // A측 투표 수 계산
     long countByaCase_IdAndType(Long caseId, DebateSide type);


### PR DESCRIPTION
[문제 원인]
- `DebateService.getDebateDetails` API 호출 시, DB에 투표(`Vote`) 또는 판결(`Judgment`) 데이터가 중복으로 존재할 경우 `NonUniqueResultException`이 발생하여 500 에러를 반환하는 문제 확인.

[해결 방법]
1. VoteRepository
   - 사용자별 최신 투표 내역 1건만 안전하게 조회하기 위해 `findTopByaCase_IdAndUser_IdOrderByVotedAtDesc` 메서드 추가.

2. DebateService
   - 투표 정보 조회 로직을 기존 `findBy...`에서 `findTop...`으로 변경하여 중복 투표 데이터가 있어도 에러 없이 최신 이력을 가져오도록 수정.
   - 판결문(초심/최종심) 조회 시에도 `findTop...OrderByCreatedAtDesc` 패턴을 적용하여 중복 생성된 판결문 중 최신 데이터 하나만 매핑하도록 개선.

## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [X] 코드 개선
- [X] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#46 ]
