### PR TITLE
[Feat] 사용자 경험치 동시성 이슈 해결 및 영속성 처리 개선

### DIFF
--- a/src/main/java/com/demoday/ddangddangddang/repository/UserRepository.java
+++ b/src/main/java/com/demoday/ddangddangddang/repository/UserRepository.java
@@ -1,11 +1,21 @@
 package com.demoday.ddangddangddang.repository;
 
 import com.demoday.ddangddangddang.domain.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
+
+    // 비관적 락(쓰기 락)을 걸어 유저 조회
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.id = :id")
+    Optional<User> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/demoday/ddangddangddang/service/ExpService.java
+++ b/src/main/java/com/demoday/ddangddangddang/service/ExpService.java
@@ -2,7 +2,10 @@ package com.demoday.ddangddangddang.service;
 
 import com.demoday.ddangddangddang.domain.ExpLog;
 import com.demoday.ddangddangddang.domain.User;
+import com.demoday.ddangddangddang.global.code.GeneralErrorCode;
+import com.demoday.ddangddangddang.global.exception.GeneralException;
 import com.demoday.ddangddangddang.repository.ExpLogRepository;
+import com.demoday.ddangddangddang.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,15 +15,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ExpService {
     private final ExpLogRepository expLogRepository;
+    private final UserRepository userRepository;
 
-    // 이 메서드를 user.addExp() 대신 사용하세요
     public void addExp(User user, Long amount, String description) {
-        // 1. 실제 유저 경험치 증가
-        user.addExp(amount);
+        // ID로 유저를 다시 조회하여 영속 상태(Managed)로 만듦 + 비관적 락 적용 권장
+        User managedUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+
+        // 1. 영속 상태인 객체의 값을 변경 (트랜잭션 종료 시 자동 Update됨)
+        managedUser.addExp(amount);
 
         // 2. 내역 저장
         ExpLog log = ExpLog.builder()
-                .user(user)
+                .user(managedUser) // 연관관계도 managedUser로 맺는 것이 안전
                 .amount(amount)
                 .description(description)
                 .build();


### PR DESCRIPTION
[문제 상황]
1. 동시성 문제: 좋아요 수신과 변론 작성 등 경험치 획득 이벤트가 동시에 발생할 경우, Race Condition으로 인해 업데이트 내용이 유실(Lost Update)되는 현상 발생.
2. 영속성 문제: `CaseService` 등에서 인증 객체(UserDetails)로부터 가져온 Detached 상태의 User 엔티티를 사용할 경우, `ExpService`를 통해 경험치를 수정해도 DB에 반영되지 않는 문제 확인.

[변경 사항]
1. UserRepository
   - `findByIdWithLock` 메서드 추가: `PESSIMISTIC_WRITE` 락을 적용하여 동시 수정 방지.

2. ExpService
   - `addExp` 메서드 로직 개선: 전달받은 User 객체를 그대로 사용하지 않고, `findByIdWithLock`을 통해 DB에서 재조회(Reload)하여 영속 상태(Managed)로 전환 후 데이터 수정.
   - 이를 통해 동시성 이슈 해결 및 Detached 엔티티 사용 시의 업데이트 누락 문제 동시 해결.

## ✨ 어떤 이유로 PR를 하셨나요?

- [X] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요


## 📸 작업 화면 스크린샷


## ⚠️ PR하기 전에 확인해주세요

- [X] 로컬테스트를 진행하셨나요?
- [X] 머지할 브랜치를 확인하셨나요?
- [X] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [#46 ]
